### PR TITLE
Travis CI for deploying to the PaaS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+cache: bundler
+bundler_args: "--without development"
+script: bundle exec middleman build
+deploy:
+  provider: cloudfoundry
+  api: https://api.cloud.service.gov.uk
+  username: michael.mokrysz+tech-docs-deployer@digital.cabinet-office.gov.uk
+  password:
+    secure: Ylc6LU9QSA1yaca/hvQDDs60bM3zxZeVnArFMWC2nKCa+AAZt1Mv78LaVeR0tX5yBo+ACJXWv+IRCt9z4wRZumZVKFuaG12g22PlxuYDaD0TsqyYdVS02HXv73Mc+vIH+szNtfvvAkrLbw8NLlA1EfZrIcE1pBBpMiRNwxeJBkenUsvC5ckZN3u1pfQ5Z4b/zRY+d1cYdiyljE/JR5MwcDYA6KVZ4PDqs2Rx9gW8e5eh6D690nWrfX3XqeGGCbCZXvjNcZOF7u+8Q3bnHF9HF2sy5SIb1ZQN3zun51KiOC4zUn48egCxMDqExuBIyl3WnwqFAO1TF5XnJWhCU54Zshy4NOJ2E1+pFvEZqTAlkT59m9bcKruexaa9IUqw7UsYkgcdHa6mR1T3ZjJ2MHsg59lCRi0A9JBH1YpnWKbawi0BtyhV90nOKgQtvIOjrl9cDAl4KqbQzj/Es+aiUBumiv2D+q0W2LRDQ3nkWiEudsZTsboX1UOcE8as7jfIhz3TyhvMBy1DBXjUPXdaQHGjAbv59WXwpRx9Bf3/nkI/1zfa5aAi6OG+1Fb856dhP98GtYi3m6RVocI7rfSAzvCr4svqCfkjuSKwbsvuIveQdifhDSnhRBNiym2m7N+PJK4qeVjm46b/U6GIL6FIDsHOSI/IbHgqW4wrsdjBsXHuMMs=
+  organization: gds-tech-ops
+  space: docs
+  on:
+    repo: alphagov/re-team-manual
+    branch: master


### PR DESCRIPTION
Travis CI for deploying to the PaaS. Already used in [alphagov/reliability-engineering](https://github.com/alphagov/reliability-engineering/commit/02116f30167fd3f7c6aa49c33005ebe00a4be344). Tested successfully in https://travis-ci.org/alphagov/re-team-manual/builds/402241252