### PR TITLE
Fix link

### DIFF
--- a/source/documentation/index.md
+++ b/source/documentation/index.md
@@ -4,4 +4,4 @@ This manual contains information to help you get started on the team and answer 
 
 It’s owned and managed by the RE team so if something is missing, please [raise a pull request](https://github.com/alphagov/re-team-manual/pulls) or [log an issue](https://github.com/alphagov/re-team-manual/issues/new) on GitHub.
 
-The team manual is not intended as guidance for anyone working outside Reliability Engineering - you’ll find that in our [external documentation]((https://reliability-engineering.cloudapps.digital/)).
+The team manual is not intended as guidance for anyone working outside Reliability Engineering - you’ll find that in our [external documentation](https://reliability-engineering.cloudapps.digital/).


### PR DESCRIPTION
Link was previously directing to
`https://re-team-manual.cloudapps.digital/(https://reliability-engineering.cloudapps.digital/)`