### PR TITLE
Add zendesk check to observe tasks

### DIFF
--- a/source/documentation/observe-support.md
+++ b/source/documentation/observe-support.md
@@ -14,6 +14,7 @@ The observe team are offering an in work hours support, this is currently 9am - 
 - Check emails for Pingdom notifications
 - Check emails for Logit and PagerDuty status updates
 - Check on the status of the Prometheus service
+- Check [Zendesk queue](https://govuk.zendesk.com/agent/dashboard) for tickets
 - Triage issues and bugs
 - Initiate the [incident process](#incident-process)
 


### PR DESCRIPTION
Some of our alerts will create tickets on a Zendesk queue so checking Zendesk will be another task of the interruptible person.