### PR TITLE
Grafana permissions

### DIFF
--- a/source/documentation/observe-support.md
+++ b/source/documentation/observe-support.md
@@ -6,7 +6,7 @@ Observe build and operate a Prometheus service for PaaS tenants, and are respons
 
 The observe team are offering an in work hours support, this is currently 9am - 6pm, Monday to Fridays. Any issues out of hours will be recorded and handled during work hours.
 
-### Observe interruptible tasks:
+### Observe interruptible tasks
 - Keep interruptible Documentation Up To Date
 - Respond to PagerDuty alerts
 - Support users on the `#re-prometheus-support` and `#reliability-eng` slack channels
@@ -25,20 +25,6 @@ Observe interruptible is a new responsibility, we are attempting to document the
 #### Respond to PagerDuty alerts
 
 PagerDuty is configured to ring the Interruptible phone when an alert is triggered. PagerDuty alerts should be acknowledged and investigated.
-
-##### If the problem is with the monitoring service (Prometheus or Alert Manager)
- - check if the services are available
- - check if there are any deployments in progress
- - check that [Grafana](https://grafana-paas.cloudapps.digital/) is pointing to a live Prometheus service by looking at the data sources under configuration.
- - check the health of the ECS cluster to make sure that the services are running in each AZ.
-
-Escalate the issue to the rest of the team if you are unable to track down the problem.
-
-If the issues are not affecting services  (Users are able to continue to use the service without any disruption) then follow the [triage process](#triage-process).
-
-##### If the problem is with one of the Prometheus tenants
-
-Put a message in slack: `#re-prometheus-support` and speak to someone in the [team](https://docs.google.com/document/d/1WLKqmpSHUbOVygkdJkewM1bj7lOK0MC-r8sBpTIHBzs/edit) who is responsible for the service which has a problem.
 
 #### Support users on the `#re-prometheus-support` and `#reliability-eng` slack channels
 
@@ -186,6 +172,24 @@ blue-green deployed apps even after the old (also known as venerable) applicatio
 [Prometheus targets](https://prom-1.monitoring.gds-reliability.engineering/targets)
 
 For more information you could [search the prometheus-aws-configuration-beta repo for the source of the alert](https://github.com/alphagov/prometheus-aws-configuration-beta/search?q=RE_Observe_Target_Down)
+
+
+## Runbook
+
+### There is a problem with the monitoring service (Prometheus or Alert Manager)
+ - check if the services are available
+ - check if there are any deployments in progress
+ - check that [Grafana](https://grafana-paas.cloudapps.digital/) is pointing to a live Prometheus service by looking at the data sources under configuration.
+ - check the health of the ECS cluster to make sure that the services are running in each AZ.
+
+Escalate the issue to the rest of the team if you are unable to track down the problem.
+
+If the issues are not affecting services  (Users are able to continue to use the service without any disruption) then follow the [triage process](#triage-process).
+
+
+### There is a problem with one of the Prometheus tenants
+
+Put a message in slack: `#re-prometheus-support` and speak to someone in the [team](https://docs.google.com/document/d/1WLKqmpSHUbOVygkdJkewM1bj7lOK0MC-r8sBpTIHBzs/edit) who is responsible for the service which has a problem.
 
 
 ### Adding and editing Grafana permissions

--- a/source/documentation/observe-support.md
+++ b/source/documentation/observe-support.md
@@ -194,9 +194,9 @@ Put a message in slack: `#re-prometheus-support` and speak to someone in the [te
 
 ### Adding and editing Grafana permissions
 
-If a user requests a change in Grafana permissions, for example so they can edit a team dashboard then you should add that user to the relevant Grafana team and ensure that the team has admin permissions for their team folder.
+If a user requests a change in Grafana permissions, for example so that they can edit a team dashboard, then you should add that user to the relevant Grafana team and ensure that the team has admin permissions for their team folder.
 
-You should not change a user's overall permissions found in **Configuration > Users** - this should remain as 'Viewer' for all users who are not part of the RE Observe team.
+Do not change a user's overall permissions found in **Configuration > Users** - this should remain as 'Viewer' for all users who are not part of the RE Observe team.
 
 
 ### Upgrading Node Exporter in Verify

--- a/source/documentation/observe-support.md
+++ b/source/documentation/observe-support.md
@@ -188,6 +188,13 @@ blue-green deployed apps even after the old (also known as venerable) applicatio
 For more information you could [search the prometheus-aws-configuration-beta repo for the source of the alert](https://github.com/alphagov/prometheus-aws-configuration-beta/search?q=RE_Observe_Target_Down)
 
 
+### Adding and editing Grafana permissions
+
+If a user requests a change in Grafana permissions, for example so they can edit a team dashboard then you should add that user to the relevant Grafana team and ensure that the team has admin permissions for their team folder.
+
+You should not change a user's overall permissions found in **Configuration > Users** - this should remain as 'Viewer' for all users who are not part of the RE Observe team.
+
+
 ### Upgrading Node Exporter in Verify
 
 #### Outline of the process


### PR DESCRIPTION
- Adds documentation for what you should do on support if a user asks for grafana permissions to be added/updated
- Adds all tasks into a `runbook` section as these previously felt split over several sections