### PR TITLE
Add documentation about RE Jenkins

### DIFF
--- a/source/documentation/using-re-jenkins.md
+++ b/source/documentation/using-re-jenkins.md
@@ -1,0 +1,9 @@
+### A secure and simple Jenkins template
+
+We provide the Terraform template to provision a secure and easy to use Jenkins platform.
+
+You can find the documentation in the [repository itself](https://github.com/alphagov/re-build-systems). In particular, consult the main `README` file and the `docs` folder.
+
+### Jenkins for the TechOps teams
+
+There is an instance of the platform running for teams in TechOps. That can be found [here](https://prod.gds-re.build.gds-reliability.engineering). The repository with its configuration can be found [here](https://github.com/alphagov/re-build-terraform).

--- a/source/joiners-and-leavers.html.md.erb
+++ b/source/joiners-and-leavers.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: "Joiners & Leavers"
-weight: 8
+weight: 9
 ---
 
 # <%= current_page.data.title %>

--- a/source/observe-support.html.md.erb
+++ b/source/observe-support.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: "Observe Support"
-weight: 6
+weight: 7
 ---
 
 # <%= current_page.data.title %>

--- a/source/operational-tasks.html.md.erb
+++ b/source/operational-tasks.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: "Operational Tasks"
-weight: 7
+weight: 8
 ---
 
 # <%= current_page.data.title %>

--- a/source/using-re-jenkins.html.md.erb
+++ b/source/using-re-jenkins.html.md.erb
@@ -1,0 +1,8 @@
+---
+title: "Using Build Tools"
+weight: 6
+---
+
+# <%= current_page.data.title %>
+
+<%= partial 'documentation/using-re-jenkins.md' %>


### PR DESCRIPTION
Brief description of the Terraform code we provide to provision a Jenkins and the instance running for teams in TechOps.
It is mostly a pointer to the documentation in the repos, so as to avoid duplicating docs.

We also needed to increment the weight of the subsequent pages.

with @samjamcul

![image](https://user-images.githubusercontent.com/22837571/46537845-3ab90680-c8aa-11e8-9bde-f33ab9f69140.png)