### PR TITLE
Change `max_toc_heading_level` from 6 to 3

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -23,7 +23,7 @@ ga_tracking_id: # TODO
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level
 # headings.
-max_toc_heading_level: 6
+max_toc_heading_level: 3
 
 # Prevent robots from indexing (e.g. whilst in development)
 prevent_indexing: true


### PR DESCRIPTION
In a recent PR https://github.com/alphagov/re-team-manual/pull/53
I added further level headings to the alerts section of the
observe playbook. As the `max_toc_heading_level` is 6 it means that
all of these headings are added to the navigation. I don't think
this is particularly useful and clutters up the navigation menu.

I have reduced the number down to 3 and I think this gives a
useable menu whilst still providing enough depth to our navigation
so users can find what they want.

This hasn't been tested with users but is just based on what
I think looks sensible.

## Before
![image](https://user-images.githubusercontent.com/7228605/48128138-79f9bf00-e27d-11e8-9973-ab651e879b7d.png)

## After
![image](https://user-images.githubusercontent.com/7228605/48128174-9138ac80-e27d-11e8-988c-ec2e1e434621.png)
