### PR TITLE
Namespace the ex-observe stuff appropriately

### DIFF
--- a/source/architectural-decisions.html.md.erb
+++ b/source/architectural-decisions.html.md.erb
@@ -1,0 +1,19 @@
+---
+title: "Architectural Decisions"
+weight: 4
+---
+
+# <%= current_page.data.title %>
+
+<%= partial 'documentation/architecture/decisions/0001-environments.md' %>
+<%= partial 'documentation/architecture/decisions/0002-configuration-management.md' %>
+<%= partial 'documentation/architecture/decisions/0003-use-ecs-for-initial-beta-buildout.md' %>
+<%= partial 'documentation/architecture/decisions/0004-cloudwatch-metrics.md' %>
+<%= partial 'documentation/architecture/decisions/0005-giving-users-prometheus-access.md' %>
+<%= partial 'documentation/architecture/decisions/0006-deploying-prometheus-to-private-networks-in-aws.md' %>
+<%= partial 'documentation/architecture/decisions/0007-use-ubuntu-18-04.md' %>
+<%= partial 'documentation/architecture/decisions/0008-use-of-verify-egress-proxies.md' %>
+<%= partial 'documentation/architecture/decisions/0009-use-cloud-init-to-build-prometheus-server.md' %>
+<%= partial 'documentation/architecture/decisions/0010-packaging-node-exporter-as-deb-for-verify.md' %>
+<%= partial 'documentation/architecture/decisions/0011-sli-for-how-reliably-do-we-deliver-pages.md' %>
+<%= partial 'documentation/architecture/decisions/0012-deploy-alertmanager-to-k8s.md' %>

--- a/source/documentation/architecture/decisions/0001-environments.md
+++ b/source/documentation/architecture/decisions/0001-environments.md
@@ -1,0 +1,33 @@
+## 1. Environments
+
+Date: 2018-04-16
+
+### Status
+
+Accepted
+
+### Context
+
+We want to have separate environments for running our software at different stages of release.
+This will be used to provide a location where changes can be tested without impacting
+production work and our users.
+
+### Decision
+
+We have decided to have N+2 separate environments: development,
+staging and production. In development, we can create as many separate
+stacks as we want. The staging environment will be where the tools
+team will test their changes. The production environment will run all
+of our users monitoring and metrics and poll each of their
+environments.
+
+Any code can be deployed to development environments.  Only code on
+the `master` branch can be deployed to staging and production.
+
+### Consequences
+
+Keeping the environments separate reduces the chance of a core change impacting
+our users and will allow us to test aspects of our system such as handling load,
+fail over testing and new, possibly behaviour changing, version upgrades. Users will
+test their prometheus related changes in our production environment and will not have access
+to the staging environment.

--- a/source/documentation/architecture/decisions/0001-environments.md
+++ b/source/documentation/architecture/decisions/0001-environments.md
@@ -1,18 +1,18 @@
-## 1. Environments
+### 1. Environments
 
 Date: 2018-04-16
 
-### Status
+#### Status
 
 Accepted
 
-### Context
+#### Context
 
 We want to have separate environments for running our software at different stages of release.
 This will be used to provide a location where changes can be tested without impacting
 production work and our users.
 
-### Decision
+#### Decision
 
 We have decided to have N+2 separate environments: development,
 staging and production. In development, we can create as many separate
@@ -24,7 +24,7 @@ environments.
 Any code can be deployed to development environments.  Only code on
 the `master` branch can be deployed to staging and production.
 
-### Consequences
+#### Consequences
 
 Keeping the environments separate reduces the chance of a core change impacting
 our users and will allow us to test aspects of our system such as handling load,

--- a/source/documentation/architecture/decisions/0002-configuration-management.md
+++ b/source/documentation/architecture/decisions/0002-configuration-management.md
@@ -1,8 +1,8 @@
-## 2. Configuration Management
+### 2. Configuration Management
 
 Date: 2018-04-18
 
-### Status
+#### Status
 
 No longer relevant.
 
@@ -10,18 +10,18 @@ This decision related to the alpha code (in
 alphagov/prometheus-aws-configuration), which is no longer being
 actively developed.
 
-### Context
+#### Context
 
 We have the requirement of adding some resources to the base cloud instances. We currently do
 this via the [cloud.conf](https://github.com/alphagov/prometheus-aws-configuration/blob/375f34600e373aa0e4c66fcae032ceee361d8c21/terraform/modules/prometheus/cloud.conf) system. This presents us with some limitations, such as configuration
 being limited to 16kb, duplication in each instance terraform and a lack of fast feedback testing.
 
-### Decision
+#### Decision
 
 We have decided to move away from cloud.conf as much as possible and instead use it to instantiate
 a masterless puppet agent which will manage the resources.
 
-### Consequences
+#### Consequences
 
 This change firstly brings us inline with the GDS Way, and most of the programs, in our selection of
 tooling. It removes the limit of 16kb of configuration and allows the reuse of existing testing tools.

--- a/source/documentation/architecture/decisions/0002-configuration-management.md
+++ b/source/documentation/architecture/decisions/0002-configuration-management.md
@@ -1,0 +1,34 @@
+## 2. Configuration Management
+
+Date: 2018-04-18
+
+### Status
+
+No longer relevant.
+
+This decision related to the alpha code (in
+alphagov/prometheus-aws-configuration), which is no longer being
+actively developed.
+
+### Context
+
+We have the requirement of adding some resources to the base cloud instances. We currently do
+this via the [cloud.conf](https://github.com/alphagov/prometheus-aws-configuration/blob/375f34600e373aa0e4c66fcae032ceee361d8c21/terraform/modules/prometheus/cloud.conf) system. This presents us with some limitations, such as configuration
+being limited to 16kb, duplication in each instance terraform and a lack of fast feedback testing.
+
+### Decision
+
+We have decided to move away from cloud.conf as much as possible and instead use it to instantiate
+a masterless puppet agent which will manage the resources.
+
+### Consequences
+
+This change firstly brings us inline with the GDS Way, and most of the programs, in our selection of
+tooling. It removes the limit of 16kb of configuration and allows the reuse of existing testing tools.
+By running in masterless mode we remove the need of running a puppet master and related infrastructure.
+Our puppet manifests can be reused both within tools and possibly other programs.
+
+It's worth noting we will still need a basic cloud.conf file to install and run the puppet agent but this
+will be minimal and reusable in each of our terraform projects. There is also the risk that people will
+put more in the puppet code than they should. This will be remediated via review of
+architecture and code.

--- a/source/documentation/architecture/decisions/0003-use-ecs-for-initial-beta-buildout.md
+++ b/source/documentation/architecture/decisions/0003-use-ecs-for-initial-beta-buildout.md
@@ -1,0 +1,39 @@
+## 3. Use Amazon ECS for initial beta build-out
+
+Date: 2018-06-21
+
+(although note that this ADR was written post hoc, a couple of months
+after the decision was made)
+
+### Status
+
+Superseded.
+
+We have now migrated prometheus off ECS and on to EC2.  The rest is
+covered in ADR #12.
+
+### Context
+
+Existing self-hosted infrastructure at GDS has been managed in code
+using tools like puppet, but in a somewhat ad hoc way with each team
+doing things differently, little sharing of code, and much reinvention
+of wheels.  We would like to learn about other ways of deploying
+infrastructure which encourage consistency: in terms of code
+artifacts, configuration methods, and such like.
+
+Systems such as Kubernetes and Amazon ECS are coalescing around Docker
+as a standard for packaging software and managing configuration.
+
+### Decision
+
+We will build our initial prometheus beta in Amazon ECS, and assess
+how effective it is.  We will review this decision once we have learnt
+more about both prometheus and ECS.
+
+### Consequences
+
+There may be ways in which Prometheus's opinions clash with ECS's
+opinions.  For example, Prometheus by default uses local disk for
+storing state, which may mean that we need to pin the prometheus
+container to a single underlying instance so that it always gets the
+same local disk.

--- a/source/documentation/architecture/decisions/0003-use-ecs-for-initial-beta-buildout.md
+++ b/source/documentation/architecture/decisions/0003-use-ecs-for-initial-beta-buildout.md
@@ -1,18 +1,18 @@
-## 3. Use Amazon ECS for initial beta build-out
+### 3. Use Amazon ECS for initial beta build-out
 
 Date: 2018-06-21
 
 (although note that this ADR was written post hoc, a couple of months
 after the decision was made)
 
-### Status
+#### Status
 
 Superseded.
 
 We have now migrated prometheus off ECS and on to EC2.  The rest is
 covered in ADR #12.
 
-### Context
+#### Context
 
 Existing self-hosted infrastructure at GDS has been managed in code
 using tools like puppet, but in a somewhat ad hoc way with each team
@@ -24,13 +24,13 @@ artifacts, configuration methods, and such like.
 Systems such as Kubernetes and Amazon ECS are coalescing around Docker
 as a standard for packaging software and managing configuration.
 
-### Decision
+#### Decision
 
 We will build our initial prometheus beta in Amazon ECS, and assess
 how effective it is.  We will review this decision once we have learnt
 more about both prometheus and ECS.
 
-### Consequences
+#### Consequences
 
 There may be ways in which Prometheus's opinions clash with ECS's
 opinions.  For example, Prometheus by default uses local disk for

--- a/source/documentation/architecture/decisions/0004-cloudwatch-metrics.md
+++ b/source/documentation/architecture/decisions/0004-cloudwatch-metrics.md
@@ -1,0 +1,81 @@
+## 4. Cloudwatch Metrics
+
+Date: 2018-06-28
+
+### Status
+
+Accepted.
+
+### Context
+
+We wanted to gather metrics from our own infrastructure so that we can drive alerts when things go wrong. Amazon exposes platform-level metrics via CloudWatch.
+Prometheus provides a [cloudwatch_exporter](https://github.com/prometheus/cloudwatch_exporter) which makes these metrics available to prometheus.
+
+We had a [spike](https://github.com/alphagov/prometheus-aws-configuration-beta/tree/cloudwatch) to see if we could use the Cloudwatch exporter to get Cloudwatch metrics and trigger alerts.
+After getting it to work with a number of metrics we were able to start to estimate costs. From these estimates we had concerns regarding the [high costs](https://aws.amazon.com/cloudwatch/pricing/)
+in running it due to the number of metrics requested using the Cloudwatch API.
+
+Each time the `/metrics` endpoint is hit triggers the exporter to retrieve
+metrics from the Cloudwatch API. Every Cloudwatch metric that you request costs
+money (regardless of if you ask for 100 metrics using 1 metric per api call or
+100 metrics using 100 metrics per api call).
+
+cost = `number of metrics on /metrics page` x `number of scrapes an hour` x `number of hours in a year` x `price of requesting a metric using the API` x `number of prometheis running across all our environments`.
+
+Based on a simple assumption of 100 metrics requested, being scraped once every 10 minutes (6 per hour), 3 Prometheis in production, 3 Prometheis in staging and 4 in dev accounts, it would work out:
+
+`100 x 6 x 24 x 365 x $0.00001 x 10 = $525.6 per year`
+
+However if we wish to scrape at the same rate we would a normal target, e.g. 30
+seconds that would become roughly $10,500 per year.
+
+100 metrics also appears to be unlikely. Based on asking for just these ALB and EBS
+metrics:
+
+```
+ApplicationELB/RequestCount
+ApplicationELB/TargetResponseTime
+ApplicationELB/HTTPCode_ELB_5XX_Count
+EBS/VolumeWriteBytes
+EBS/VolumeReadBytes
+EBS/VolumeReadOps
+EBS/VolumeWriteOps
+```
+
+we appear to be requesting roughly 4000 metrics per scrape. If we scraped our current config at a period of once every 10 minutes we would end up roughly $21,000 a year. If we scraped it every 30 seconds it would be about $420,000.
+
+By requesting only ALB metrics in the dev accounts, we still produce about 160 API requests according to the `cloudwatch_requests_total` counter for each scrape. Somewhat strangely, this only returns about 30 timeseries so we are not sure if our config is incorrect and if the number of API calls could be reduced to closer match the number of timeseries.
+
+Note, as dev accounts have lots of resources e.g. volumes, there may be fewer
+metrics requested for staging and prod as unlike the dev account we wouldn't be
+exporting metrics for other stacks.
+
+It takes a long time to get a response from the /metrics endpoint as it needs to make many API calls. This causes slow response times for which our prometheus scrape config needs to allow for using the `scrape_timeout` setting.
+
+We found the Cloudwatch exporter app to be very CPU intensive, we had to double our standard instance size to a `m4.2xlarge` to get it to work. We were also concerned about having such a CPU intensive task running in the same instance as Prometheus.
+
+Because we fetch config from S3 using a sidecar container, there is a race condition between fetching config and starting cloudwatch_exporet.  We found that this condition was encountered every time, meaning either a 2nd restart of the task was needed or we would need to add a delay to the exporter starting. We did not try and solve this.
+
+The exporter task is slow to start up, the health check needs longer than usual to pass health checks.
+
+We spotted that several targets we are scraping, such as prometheus and alertmanager, are set at very short scrape intervals (every 5s), this seems excessive and we can likely change down to every 30secs regardless of this story.
+
+There is roughly a 15 minute delay in Cloudwatch metrics.  The [Prometheus CloudWatch exporter README](https://github.com/prometheus/cloudwatch_exporter/blob/master/README.md) explains it:
+
+> CloudWatch has been observed to sometimes take minutes for reported values to converge. The default delay_seconds will result in data that is at least 10 minutes old being requested to mitigate this.
+
+### Decision
+
+We will not use the cloudwatch_exporter to gather Cloudwatch metrics into prometheus.
+
+### Consequences
+
+We will not have alerts for EBS volumes not being attached to the instances, which was a concern as Prometheus would start but no metrics stored.
+
+This has however been fixed in [this commit](https://github.com/alphagov/prometheus-aws-configuration-beta/commit/cd2432045dfd8fc10d7fa1ae34f4dfed63fc9f11), which resolves this by causing the user data script to exit with failure when the volume is not attached.
+
+No alert is raised but the failure is no longer silent as Prometheus will no longer run without an attached EBS volume.
+
+We also don't have metrics available for ALBs and other parts of our AWS infrastructure.
+
+We need to explore other solutions to get these metrics that are more cost-efficient.

--- a/source/documentation/architecture/decisions/0004-cloudwatch-metrics.md
+++ b/source/documentation/architecture/decisions/0004-cloudwatch-metrics.md
@@ -1,12 +1,12 @@
-## 4. Cloudwatch Metrics
+### 4. Cloudwatch Metrics
 
 Date: 2018-06-28
 
-### Status
+#### Status
 
 Accepted.
 
-### Context
+#### Context
 
 We wanted to gather metrics from our own infrastructure so that we can drive alerts when things go wrong. Amazon exposes platform-level metrics via CloudWatch.
 Prometheus provides a [cloudwatch_exporter](https://github.com/prometheus/cloudwatch_exporter) which makes these metrics available to prometheus.
@@ -64,11 +64,11 @@ There is roughly a 15 minute delay in Cloudwatch metrics.  The [Prometheus Cloud
 
 > CloudWatch has been observed to sometimes take minutes for reported values to converge. The default delay_seconds will result in data that is at least 10 minutes old being requested to mitigate this.
 
-### Decision
+#### Decision
 
 We will not use the cloudwatch_exporter to gather Cloudwatch metrics into prometheus.
 
-### Consequences
+#### Consequences
 
 We will not have alerts for EBS volumes not being attached to the instances, which was a concern as Prometheus would start but no metrics stored.
 

--- a/source/documentation/architecture/decisions/0005-giving-users-prometheus-access.md
+++ b/source/documentation/architecture/decisions/0005-giving-users-prometheus-access.md
@@ -1,0 +1,42 @@
+## 5. Give users access to Prometheus and Alertmanager
+
+Date: 2018-08-08
+
+### Status
+
+Accepted.
+
+### Context
+
+Our users need an easier way to write alerts.  They currently have no
+easy way to test queries before writing their alerts.
+
+In principle, they could use Prometheus's expression browser for this,
+but our Prometheus service requires basic auth, which locks our users
+out of it.
+
+### Decision
+
+We will give our users access to Prometheus so they can use its
+expression browser to test queries when writing alerts. We will
+do this by using IP whitelisting instead of basic auth and
+only allowing our office IP addresses.
+
+We identified a number of different routes that we could have taken to
+allow our users to access Prometheus.  One possible route that we
+considered was using Oauth2 authentication. This would enable users to
+authenticate themselves to the platform with their Google account.
+
+We did not choose to go with this option this time for expediency.
+The idea behind this was to try to deliver the fastest value as
+possible to the user. This method enables us to learn more about the user's
+usage pattern. We do intend to add authentication but this will be done at
+a later date.
+
+### Consequences
+
+Anyone in the office can access Prometheus and Alertmanager. This means that
+they can use expression browser in order to dynamically test and create queries
+with fast feedback loop.
+
+With IP whitelisting, we are not able to track our users.

--- a/source/documentation/architecture/decisions/0005-giving-users-prometheus-access.md
+++ b/source/documentation/architecture/decisions/0005-giving-users-prometheus-access.md
@@ -1,12 +1,12 @@
-## 5. Give users access to Prometheus and Alertmanager
+### 5. Give users access to Prometheus and Alertmanager
 
 Date: 2018-08-08
 
-### Status
+#### Status
 
 Accepted.
 
-### Context
+#### Context
 
 Our users need an easier way to write alerts.  They currently have no
 easy way to test queries before writing their alerts.
@@ -15,7 +15,7 @@ In principle, they could use Prometheus's expression browser for this,
 but our Prometheus service requires basic auth, which locks our users
 out of it.
 
-### Decision
+#### Decision
 
 We will give our users access to Prometheus so they can use its
 expression browser to test queries when writing alerts. We will
@@ -33,7 +33,7 @@ possible to the user. This method enables us to learn more about the user's
 usage pattern. We do intend to add authentication but this will be done at
 a later date.
 
-### Consequences
+#### Consequences
 
 Anyone in the office can access Prometheus and Alertmanager. This means that
 they can use expression browser in order to dynamically test and create queries

--- a/source/documentation/architecture/decisions/0006-deploying-prometheus-to-private-networks-in-aws.md
+++ b/source/documentation/architecture/decisions/0006-deploying-prometheus-to-private-networks-in-aws.md
@@ -1,0 +1,232 @@
+## 6. Model for deploying prometheus to private networks in AWS
+
+Date: 2018-07-26
+
+### Status
+
+Draft
+
+### Context
+
+We are looking to offer prometheus to non-PaaS teams.  The
+infrastructure to be monitored will be run by another team (called
+"client team" in this document), but we will provide one or more
+prometheus servers which will will be responsible for gathering
+metrics from the underlying infrastructure.
+
+Longer term, we are aiming to provide prometheus as a service to
+multiple environments across multiple programmes.
+
+#### Non-suitability of existing infrastructure
+
+Our existing prometheus infrastructure (for PaaS teams) works by using
+our [service broker][] to generate file_sd_configs which prometheus
+then uses to scrape PaaS apps over the public internet.
+
+This approach won't work for non-PaaS teams, because it's based on an
+assumption – that every app is directly routable from the public
+internet – that doesn't hold in non-PaaS environments.  Instead, apps
+live on private networks and public access is controlled by firewalls
+and load balancers.
+
+[service broker]: https://github.com/alphagov/cf_app_discovery
+
+#### Main problem to be solved: scraping apps on private networks
+
+As the previous section explained, our main problem is that we want a
+prometheus (provided by us) to be able to scrape apps and other
+endpoints (owned by the client team, and living on a private network).
+We want to do this in a way which doesn't require clients to
+unnecessarily expose metrics endpoints to the public internet.
+
+Some other things we would like to be able to do are:
+
+ - maintain prometheus at a single common version, by upgrading
+   prometheus across our whole estate
+ - update prometheus configuration without having to restart
+   prometheus
+ - allow client teams to provide configuration (for example, for alert
+   rules)
+ - perform [ec2 service discovery][] by querying the EC2 API (for
+   which we need permissions to read client account EC2 resources)
+
+There are several ways we might provide a prometheus pattern that
+allows us to scrape private endpoints:
+
+ - provide an artefact to be deployed by the client team
+ - client team provides IAM access to us and we deploy prometheus
+   ourselves, within their VPC
+ - we build in our own infrastructure and use VPC peering to access
+   client team's private networks
+ - we build in our own infrastructure and use VPC Endpoint Services as
+   a way to get prometheus to access client team's private networks
+
+[ec2 service discovery]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#%3Cec2_sd_config%3E
+
+#### Provide an artefact to be deployed by the client team
+
+The artefact we provide could take several forms:
+
+ - an AMI (amazon machine image) which the client team deploys as an
+   EC2 instance
+ - a terraform module which the client team includes in their own
+   terraform project
+
+This model has the downside that it doesn't allow us to maintain
+prometheus at a single common version, because we are at the mercy of
+client teams' deploy cadences to ensure things get upgraded.
+
+#### Client team provides IAM access so that we can deploy prometheus ourselves
+
+In this model, the client team would create an IAM Role and allow us
+to assume it, so that we can build our own prometheus infrastructure
+within their VPC.
+
+This would mean that the client team needs to do some work to provide
+us with the correct IAM policies so that we can do what we need to do,
+without giving us more capability than they feel comfortable with.
+
+The client team would have visibility over what we had built, and
+would be able to see it in their own AWS console.  However, they would
+likely not have ssh access to the instance itself.
+
+One possible issue with this model is that we're beholden on the
+client to provide us with a CIDR range to deploy onto, and depending
+on their existing estate, private IPs may be in short supply.
+
+You're also dependent on their networking arrangements.  You will need
+to ask questions like:
+
+ - how can you get in and out of the network?
+ - do you need to download packages to install?  how will that work?
+ - do you need to download security updates?  how will that work?
+
+The answers to these questions may be different for different client
+teams.  This means that our prometheus pattern needs to be flexible
+enough to cope with these differences, which will take extra
+engineering effort.
+
+We would need to work out what the integration point between our teams
+would be.  This could be:
+
+ - terraform outputs that appear in a remote state file
+   - or stereotyped resource names/tags which can be matched using
+     data sources
+
+Whether or not we go with this option for deploying prometheus, if we
+want to do ec2 service discovery (described above), prometheus will
+need some sort of IAM access into the client team account anyway.
+
+#### Use VPC Peering to provide access for prometheus to scrape target infrastructure
+
+[VPC Peering][] is a feature which allows you to establish a
+networking connection between two VPCs.  In particular, this is a
+peering arrangement which means that the two networks on either side
+of the VPC Peering arrangement cannot share the same IP address
+ranges.
+
+Crucially for us, the VPCs can be in different AWS accounts.
+
+This means that we could build Prometheus in an account we own, and it
+could access client team infrastructure over the peering connection.
+Running our own infrastructure in our own account without being
+dependent on client teams providing anything to us would make for
+smoother operations and deployments for us.
+
+This has a drawback for the client in that it adds extra points of
+ingress and egress for traffic in the client networks.  This increases
+the attack surface of the network which makes doing a security audit
+harder and makes it harder to have confidence in the security of the
+system.
+
+There's also a drawback in terms of the combination of connections: as
+RE builds more services that might be provided to client teams, and as
+we extend these services to more client teams, we end up with N*M VPC
+peering connections to maintain.
+
+As RE (and techops more broadly) provides more services, client teams
+end up having to consider more VPC Peering connections in their
+security analyses, and this doesn't feel like a particularly scalable
+way for us to offer services to client teams.
+
+Finally, we believe that VPC Peering is something that has to be
+accepted manually on the receiving account console (at least when
+peering across AWS accounts), which compounds the scaling problem.
+
+There are two sub cases worth exploring here:
+
+##### A single prometheus VPC peers with multiple client VPCs
+
+In this model, we would build a single prometheus service in a VPC
+owned by us, and it would have VPC peering arrangements with multiple
+client team VPCs in order to scrape metrics from each of them.
+
+This has the benefit that we can run fewer instances to scrape metrics
+from the same number of environments.
+
+This has some drawbacks:
+
+ - the single VPC becomes more privileged, because it has access to
+   more environments.  This means that a compromise of the prometheus
+   VPC could lead to a compromise of more clients' VPCs.
+
+##### A single prometheus VPC peers with only a single client VPC
+
+In this scenario, we would build a single prometheus in its own VPC
+for each client team VPC we offer the service to.
+
+This avoids some of the drawbacks of the previous case, in that the
+prometheus doesn't have privileges to access multiple separate VPCs.
+
+[VPC Peering]: https://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide/Welcome.html
+
+#### Use VPC Endpoint Services to access scrape targets
+
+This is a similar idea to VPC Peering.  [VPC Endpoint Services][] (aka
+AWS PrivateLink) provides a way to provide services to a VPC, again
+potentially in another account.
+
+This allows you to make a single Network Load Balancer (NLB) appear
+directly available (ie without going through a NAT Gateway) in another
+VPC.
+
+In the case of Prometheus, because it has a pull model, it seems
+likely that the only way we could make this work would be by having
+the client team provide the endpoint service and prometheus consume
+it.  This would mean the client team would need to add a routing layer
+(possibly path- or vhost-based routing, possibly using an ALB) to
+distribute scrape requests to individual scrape targets.
+
+This has the following advantages:
+
+ - the IP address spaces in the prometheus VPC and the client team VPC
+   are completely independent
+
+However it has some drawbacks:
+
+ - it feels like we're not using Endpoint Services in a designed use
+   case. in other words, it feels like a bit of a hack.
+ - Prometheus is designed to be close to its targets, so that there
+   are fewer things to go wrong and prevent scraping.  The more layers
+   of routing between prometheus and its scrape targets, the more
+   chance we'll lose metrics during an outage, exactly when we need
+   them.
+
+[VPC Endpoint Services]: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/endpoint-service.html
+
+### Decision
+
+- Deploy Prometheus into Verify Performance Environment to test concept
+- Deploy an instance of Prometheus into the client teams VPC
+- Use Ubuntu 18.04 as the distribution for the instance [ADR-7](0007-use-ubuntu-18-04.md)
+- Use Cloud Init to configure Prometheus [ADR-9](0009-use-cloud-init-to-build-prometheus-server.md)
+- Use Verify infrastructure initially for the PoC [ADR-8](0008-use-of-egress-proxies.md)[ADR-10](0010-packaging-node-exporter-as-deb-for-verify.md)
+
+### Consequences
+
+We haven't yet solved the problem of how client teams provide alert
+configuration to prometheus.
+
+For the moment, it is acceptable to define configuration in
+cloud-init, but this does not meet our need to update configuration
+without rebuilding instances so we will need to revise this in future.

--- a/source/documentation/architecture/decisions/0006-deploying-prometheus-to-private-networks-in-aws.md
+++ b/source/documentation/architecture/decisions/0006-deploying-prometheus-to-private-networks-in-aws.md
@@ -1,12 +1,12 @@
-## 6. Model for deploying prometheus to private networks in AWS
+### 6. Model for deploying prometheus to private networks in AWS
 
 Date: 2018-07-26
 
-### Status
+#### Status
 
 Draft
 
-### Context
+#### Context
 
 We are looking to offer prometheus to non-PaaS teams.  The
 infrastructure to be monitored will be run by another team (called
@@ -17,7 +17,7 @@ metrics from the underlying infrastructure.
 Longer term, we are aiming to provide prometheus as a service to
 multiple environments across multiple programmes.
 
-#### Non-suitability of existing infrastructure
+##### Non-suitability of existing infrastructure
 
 Our existing prometheus infrastructure (for PaaS teams) works by using
 our [service broker][] to generate file_sd_configs which prometheus
@@ -31,7 +31,7 @@ and load balancers.
 
 [service broker]: https://github.com/alphagov/cf_app_discovery
 
-#### Main problem to be solved: scraping apps on private networks
+##### Main problem to be solved: scraping apps on private networks
 
 As the previous section explained, our main problem is that we want a
 prometheus (provided by us) to be able to scrape apps and other
@@ -63,7 +63,7 @@ allows us to scrape private endpoints:
 
 [ec2 service discovery]: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#%3Cec2_sd_config%3E
 
-#### Provide an artefact to be deployed by the client team
+##### Provide an artefact to be deployed by the client team
 
 The artefact we provide could take several forms:
 
@@ -76,7 +76,7 @@ This model has the downside that it doesn't allow us to maintain
 prometheus at a single common version, because we are at the mercy of
 client teams' deploy cadences to ensure things get upgraded.
 
-#### Client team provides IAM access so that we can deploy prometheus ourselves
+##### Client team provides IAM access so that we can deploy prometheus ourselves
 
 In this model, the client team would create an IAM Role and allow us
 to assume it, so that we can build our own prometheus infrastructure
@@ -117,7 +117,7 @@ Whether or not we go with this option for deploying prometheus, if we
 want to do ec2 service discovery (described above), prometheus will
 need some sort of IAM access into the client team account anyway.
 
-#### Use VPC Peering to provide access for prometheus to scrape target infrastructure
+##### Use VPC Peering to provide access for prometheus to scrape target infrastructure
 
 [VPC Peering][] is a feature which allows you to establish a
 networking connection between two VPCs.  In particular, this is a
@@ -155,7 +155,7 @@ peering across AWS accounts), which compounds the scaling problem.
 
 There are two sub cases worth exploring here:
 
-##### A single prometheus VPC peers with multiple client VPCs
+###### A single prometheus VPC peers with multiple client VPCs
 
 In this model, we would build a single prometheus service in a VPC
 owned by us, and it would have VPC peering arrangements with multiple
@@ -170,7 +170,7 @@ This has some drawbacks:
    more environments.  This means that a compromise of the prometheus
    VPC could lead to a compromise of more clients' VPCs.
 
-##### A single prometheus VPC peers with only a single client VPC
+###### A single prometheus VPC peers with only a single client VPC
 
 In this scenario, we would build a single prometheus in its own VPC
 for each client team VPC we offer the service to.
@@ -180,7 +180,7 @@ prometheus doesn't have privileges to access multiple separate VPCs.
 
 [VPC Peering]: https://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide/Welcome.html
 
-#### Use VPC Endpoint Services to access scrape targets
+##### Use VPC Endpoint Services to access scrape targets
 
 This is a similar idea to VPC Peering.  [VPC Endpoint Services][] (aka
 AWS PrivateLink) provides a way to provide services to a VPC, again
@@ -214,7 +214,7 @@ However it has some drawbacks:
 
 [VPC Endpoint Services]: https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/endpoint-service.html
 
-### Decision
+#### Decision
 
 - Deploy Prometheus into Verify Performance Environment to test concept
 - Deploy an instance of Prometheus into the client teams VPC
@@ -222,7 +222,7 @@ However it has some drawbacks:
 - Use Cloud Init to configure Prometheus [ADR-9](0009-use-cloud-init-to-build-prometheus-server.md)
 - Use Verify infrastructure initially for the PoC [ADR-8](0008-use-of-egress-proxies.md)[ADR-10](0010-packaging-node-exporter-as-deb-for-verify.md)
 
-### Consequences
+#### Consequences
 
 We haven't yet solved the problem of how client teams provide alert
 configuration to prometheus.

--- a/source/documentation/architecture/decisions/0007-use-ubuntu-18-04.md
+++ b/source/documentation/architecture/decisions/0007-use-ubuntu-18-04.md
@@ -1,20 +1,20 @@
-## 7. Use Ubuntu 18.04
+### 7. Use Ubuntu 18.04
 
 Date: 2018-08-15
 
-### Status
+#### Status
 
 Accepted
 
-### Context
+#### Context
 
 Prometheus needs to run on a Linux distribution. The choice of distribution impacts the methods of packaging, deploying and configuring Prometheus. It is important to consider what is currently used across GDS as prior experience of distribution is helpful when supporting the service. Ubuntu is currently in use in Verify and GOV.uk (and possibly others) which provides a pool operators with the experience to be able to support the service.
 Alternatives considered were Amazon Linux, the advantage of this distribution is that it is optimised to the Amazon cloud, however this advantage did not overcome the advantage of familiarity across GDS Reliability Engineering
 
-### Decision
+#### Decision
 
 Use Ubuntu 18.04 LTS
 
-### Consequences
+#### Consequences
 
 Ubuntu provide security updates and support until 2023, reducing the support burden. The use of Ubuntu matches other programs choice.

--- a/source/documentation/architecture/decisions/0007-use-ubuntu-18-04.md
+++ b/source/documentation/architecture/decisions/0007-use-ubuntu-18-04.md
@@ -1,0 +1,20 @@
+## 7. Use Ubuntu 18.04
+
+Date: 2018-08-15
+
+### Status
+
+Accepted
+
+### Context
+
+Prometheus needs to run on a Linux distribution. The choice of distribution impacts the methods of packaging, deploying and configuring Prometheus. It is important to consider what is currently used across GDS as prior experience of distribution is helpful when supporting the service. Ubuntu is currently in use in Verify and GOV.uk (and possibly others) which provides a pool operators with the experience to be able to support the service.
+Alternatives considered were Amazon Linux, the advantage of this distribution is that it is optimised to the Amazon cloud, however this advantage did not overcome the advantage of familiarity across GDS Reliability Engineering
+
+### Decision
+
+Use Ubuntu 18.04 LTS
+
+### Consequences
+
+Ubuntu provide security updates and support until 2023, reducing the support burden. The use of Ubuntu matches other programs choice.

--- a/source/documentation/architecture/decisions/0008-use-of-verify-egress-proxies.md
+++ b/source/documentation/architecture/decisions/0008-use-of-verify-egress-proxies.md
@@ -1,22 +1,22 @@
-## 8. Use of Verify Egress Proxies
+### 8. Use of Verify Egress Proxies
 
 Date: 2018-08-15
 
-### Status
+#### Status
 
 Accepted
 
-### Context
+#### Context
 
 Verify employ egress proxies to control access to external resources.
 These are a security measure to help prevent data from being exfiltrated from within Verify.
 The Prometheus server will need access to external resources, notibly an Ubuntu APT mirror during the bootstrap process.
 The Prometheus server should not setup it's own routes to bypass the egress proxy i.e. use a NAT gateway or Elastic IP, as this will potentially open up a route for data exfiltration.
 
-### Decision
+#### Decision
 
 The Prometheus server should use Verify's egress proxies and choice of APT mirror.
 
-### Consequences
+#### Consequences
 
 This creates a binding to Verify's infrastructure, this should be considered as a temporary compromise until the Prometheus server is built as a machine image

--- a/source/documentation/architecture/decisions/0008-use-of-verify-egress-proxies.md
+++ b/source/documentation/architecture/decisions/0008-use-of-verify-egress-proxies.md
@@ -1,0 +1,22 @@
+## 8. Use of Verify Egress Proxies
+
+Date: 2018-08-15
+
+### Status
+
+Accepted
+
+### Context
+
+Verify employ egress proxies to control access to external resources.
+These are a security measure to help prevent data from being exfiltrated from within Verify.
+The Prometheus server will need access to external resources, notibly an Ubuntu APT mirror during the bootstrap process.
+The Prometheus server should not setup it's own routes to bypass the egress proxy i.e. use a NAT gateway or Elastic IP, as this will potentially open up a route for data exfiltration.
+
+### Decision
+
+The Prometheus server should use Verify's egress proxies and choice of APT mirror.
+
+### Consequences
+
+This creates a binding to Verify's infrastructure, this should be considered as a temporary compromise until the Prometheus server is built as a machine image

--- a/source/documentation/architecture/decisions/0009-use-cloud-init-to-build-prometheus-server.md
+++ b/source/documentation/architecture/decisions/0009-use-cloud-init-to-build-prometheus-server.md
@@ -1,0 +1,23 @@
+## 9. Use Cloud Init to build Prometheus Server
+
+Date: 2018-08-15
+
+### Status
+
+Accepted
+
+### Context
+
+The Prometheus Server needs to be built in a reproducible way within AWS.
+Reproducible in this context means that the server can be built, destroyed and rebuilt.
+The rebuilt server will be identical to the original server and the is no external intervention required (i.e. logging into the server to make changes to configuration)
+
+### Decision
+
+Cloud init will be used to build a reproducible server.
+
+### Consequences
+
+The cloud init was chosen over other strategies such as creating a machine image because there is prior art for building a Prometheus server with cloud init and building machine images requires additional tools.
+It was felt that cloud init will be the fastest way to achieve the short term goals.
+The use of cloud init should be reviewed at the earliest opportunity.

--- a/source/documentation/architecture/decisions/0009-use-cloud-init-to-build-prometheus-server.md
+++ b/source/documentation/architecture/decisions/0009-use-cloud-init-to-build-prometheus-server.md
@@ -1,22 +1,22 @@
-## 9. Use Cloud Init to build Prometheus Server
+### 9. Use Cloud Init to build Prometheus Server
 
 Date: 2018-08-15
 
-### Status
+#### Status
 
 Accepted
 
-### Context
+#### Context
 
 The Prometheus Server needs to be built in a reproducible way within AWS.
 Reproducible in this context means that the server can be built, destroyed and rebuilt.
 The rebuilt server will be identical to the original server and the is no external intervention required (i.e. logging into the server to make changes to configuration)
 
-### Decision
+#### Decision
 
 Cloud init will be used to build a reproducible server.
 
-### Consequences
+#### Consequences
 
 The cloud init was chosen over other strategies such as creating a machine image because there is prior art for building a Prometheus server with cloud init and building machine images requires additional tools.
 It was felt that cloud init will be the fastest way to achieve the short term goals.

--- a/source/documentation/architecture/decisions/0010-packaging-node-exporter-as-deb-for-verify.md
+++ b/source/documentation/architecture/decisions/0010-packaging-node-exporter-as-deb-for-verify.md
@@ -1,20 +1,20 @@
-## 10. Packaging Node Exporter as .deb for Verify
+### 10. Packaging Node Exporter as .deb for Verify
 
 Date: 2018-08-15
 
-### Status
+#### Status
 
 Accepted
 
-### Context
+#### Context
 
 Node Exporter needs to be installed on Verify's infrastructure so that machine metrics can be gathered.
 Verify runs Ubuntu Trusty which does not have an existing node exporter package.
 Verify has an existing workflow for packaging binaries which can be leveraged to package node exporter.
-### Decision
+#### Decision
 
 Node exporter will be packaged as a deb using FPM following Verify's exiting packaging workflow.
 
-### Consequences
+#### Consequences
 
 The use of Verify's infrastructure ties the Node exporter package to Verify, the node exporter would need to be repackaged for other programs to be able to be used.

--- a/source/documentation/architecture/decisions/0010-packaging-node-exporter-as-deb-for-verify.md
+++ b/source/documentation/architecture/decisions/0010-packaging-node-exporter-as-deb-for-verify.md
@@ -1,0 +1,20 @@
+## 10. Packaging Node Exporter as .deb for Verify
+
+Date: 2018-08-15
+
+### Status
+
+Accepted
+
+### Context
+
+Node Exporter needs to be installed on Verify's infrastructure so that machine metrics can be gathered.
+Verify runs Ubuntu Trusty which does not have an existing node exporter package.
+Verify has an existing workflow for packaging binaries which can be leveraged to package node exporter.
+### Decision
+
+Node exporter will be packaged as a deb using FPM following Verify's exiting packaging workflow.
+
+### Consequences
+
+The use of Verify's infrastructure ties the Node exporter package to Verify, the node exporter would need to be repackaged for other programs to be able to be used.

--- a/source/documentation/architecture/decisions/0011-sli-for-how-reliably-do-we-deliver-pages.md
+++ b/source/documentation/architecture/decisions/0011-sli-for-how-reliably-do-we-deliver-pages.md
@@ -1,0 +1,47 @@
+## 11. SLI for how reliably do we deliver pages
+
+Date: 2018-10-25
+
+### Status
+
+Accepted
+
+### Context
+
+https://trello.com/c/56qyWJ60/675-show-an-sli-how-reliably-do-we-deliver-pages
+
+We wish to have a service level indicator for how reliably do we deliver pages. We believe the way to measure this is to calculate for a given time period:
+
+`the number of incidents created in pagerduty / the number of incidents that we expect to have been created in pagerduty`
+
+#### Calculating the number of incidents created in pagerduty
+
+We think we can work out how many incidents there have been within a provided timeframe using the pagerduty API. We have done this for our pagerduty account successfully using a few lines of Ruby code. We would need to have access to every other teams account in order to know about all incidents and not just ones for our team. We did not spend time trying to actually do this. We would also need to run a exporter to export this information from pagerduty so Prometheus could scrape it.
+
+#### Calculating the number of incidents that we expect to have been created in pagerduty
+
+The main source of information is the `ALERTS` metric in Prometheus but there are a few problems with this.
+
+##### Problem 1
+
+At the moment we don’t have a way of identifying which alerts are tickets and which are pages. Some metrics include this information using labels but not all do. We could solve this if needed to by adding severity labels to all alerts and adding documentation so our users would also do this.
+
+##### Problem 2
+
+Prometheus doesn’t provide a metric for how many incidents we believe should have been created. Prometheus instead has metrics which measure if alerts are currently firing. We would need to reliabily turn the `ALERTS` metrics into a single metric for how many incidents we believe should have been created.
+
+We came up with:
+
+```count(ALERTS{alertstate="firing", severity="page"}) or vector(0)```
+
+We think that from here we can use the `increase` function to tell us how many times alerts have begun firing. To use this we think we would need to use recording rules as per https://www.robustperception.io/composing-range-vector-functions-in-promql to turn our query into a single range vector.
+
+At that point we should have a number for how many alerts have begun firing in a given time period. However we are not confident that this number is equal to the number of pagerduty incidents we expect to be created. The reason for this is because Alertmanager [groups firing alerts](https://prometheus.io/docs/alerting/alertmanager/#grouping), meaning multiple firing alerts may only result in one notification and therefore one incident. A potential way around this would be to try and edit the grouping behaviour of Alertmanager using it's config but it [doesn't look it's possible to turn it off completely](https://groups.google.com/forum/#!topic/prometheus-users/35znfrwu_z8). There could also be issues if an alert fires, then resolves itself, and then fires immediately after only triggering an single incident.
+
+### Decision
+
+We have decided not to try and implement this SLI at the moment as we are not confident that we can accurately calculate the number of incidents we expect in Pagerduty for a given time period using metrics from Prometheus. It might be possible but would require a few days to investigate if so and would likely end up with a somewhat complex system to measure this SLI. We could change this decision if we become more confident.
+
+### Consequences
+
+We do not measure one of our main user journeys accurately and thus can't alert if there are problems with it. We may instead have to use a proxy or measure individual components that make up the user journey instead which may be easier to measure but less accurate.

--- a/source/documentation/architecture/decisions/0011-sli-for-how-reliably-do-we-deliver-pages.md
+++ b/source/documentation/architecture/decisions/0011-sli-for-how-reliably-do-we-deliver-pages.md
@@ -1,12 +1,12 @@
-## 11. SLI for how reliably do we deliver pages
+### 11. SLI for how reliably do we deliver pages
 
 Date: 2018-10-25
 
-### Status
+#### Status
 
 Accepted
 
-### Context
+#### Context
 
 https://trello.com/c/56qyWJ60/675-show-an-sli-how-reliably-do-we-deliver-pages
 
@@ -14,19 +14,19 @@ We wish to have a service level indicator for how reliably do we deliver pages. 
 
 `the number of incidents created in pagerduty / the number of incidents that we expect to have been created in pagerduty`
 
-#### Calculating the number of incidents created in pagerduty
+##### Calculating the number of incidents created in pagerduty
 
 We think we can work out how many incidents there have been within a provided timeframe using the pagerduty API. We have done this for our pagerduty account successfully using a few lines of Ruby code. We would need to have access to every other teams account in order to know about all incidents and not just ones for our team. We did not spend time trying to actually do this. We would also need to run a exporter to export this information from pagerduty so Prometheus could scrape it.
 
-#### Calculating the number of incidents that we expect to have been created in pagerduty
+##### Calculating the number of incidents that we expect to have been created in pagerduty
 
 The main source of information is the `ALERTS` metric in Prometheus but there are a few problems with this.
 
-##### Problem 1
+###### Problem 1
 
 At the moment we don’t have a way of identifying which alerts are tickets and which are pages. Some metrics include this information using labels but not all do. We could solve this if needed to by adding severity labels to all alerts and adding documentation so our users would also do this.
 
-##### Problem 2
+###### Problem 2
 
 Prometheus doesn’t provide a metric for how many incidents we believe should have been created. Prometheus instead has metrics which measure if alerts are currently firing. We would need to reliabily turn the `ALERTS` metrics into a single metric for how many incidents we believe should have been created.
 
@@ -38,10 +38,10 @@ We think that from here we can use the `increase` function to tell us how many t
 
 At that point we should have a number for how many alerts have begun firing in a given time period. However we are not confident that this number is equal to the number of pagerduty incidents we expect to be created. The reason for this is because Alertmanager [groups firing alerts](https://prometheus.io/docs/alerting/alertmanager/#grouping), meaning multiple firing alerts may only result in one notification and therefore one incident. A potential way around this would be to try and edit the grouping behaviour of Alertmanager using it's config but it [doesn't look it's possible to turn it off completely](https://groups.google.com/forum/#!topic/prometheus-users/35znfrwu_z8). There could also be issues if an alert fires, then resolves itself, and then fires immediately after only triggering an single incident.
 
-### Decision
+#### Decision
 
 We have decided not to try and implement this SLI at the moment as we are not confident that we can accurately calculate the number of incidents we expect in Pagerduty for a given time period using metrics from Prometheus. It might be possible but would require a few days to investigate if so and would likely end up with a somewhat complex system to measure this SLI. We could change this decision if we become more confident.
 
-### Consequences
+#### Consequences
 
 We do not measure one of our main user journeys accurately and thus can't alert if there are problems with it. We may instead have to use a proxy or measure individual components that make up the user journey instead which may be easier to measure but less accurate.

--- a/source/documentation/architecture/decisions/0012-deploy-alertmanager-to-k8s.md
+++ b/source/documentation/architecture/decisions/0012-deploy-alertmanager-to-k8s.md
@@ -1,12 +1,12 @@
-## 12. Deploying alertmanager to the new platform
+### 12. Deploying alertmanager to the new platform
 
 Date: 2018-11-06
 
-### Status
+#### Status
 
 Accepted
 
-### Context
+#### Context
 
 The Observe team is a part of the new platform team, which is building out kubernetes capability in GDS.
 
@@ -40,7 +40,7 @@ Nevertheless, we could leave alertmanager in ECS but still ease some of the pain
 
 (Prometheus is different: we want to run prometheus the same way that non-PaaS teams such as Verify or Pay run it, so that we can offer guidance to them. The principle is the same: we want to run things the same way other GDS teams run them.)
 
-### Decision
+#### Decision
 
 1. We will pause any work migrating alertmanager to EC2
 2. We will run an alertmanager in the new platform, leaving the remaining alertmanagers in ECS
@@ -48,7 +48,7 @@ Nevertheless, we could leave alertmanager in ECS but still ease some of the pain
 4. We will refactor our terraform for ECS to be module-based rather than the old project-and-Makefile style, so that we reduce the different types of code and deployment style.
 5. We will keep prometheus running in EC2 and not migrate it to the new platform (although new platform environments will each have a prometheus available to them)
 
-### Consequences
+#### Consequences
 
 We will have to be careful to keep alertmanager configuration in sync between the old and new infrascture.
 

--- a/source/documentation/architecture/decisions/0012-deploy-alertmanager-to-k8s.md
+++ b/source/documentation/architecture/decisions/0012-deploy-alertmanager-to-k8s.md
@@ -1,0 +1,55 @@
+## 12. Deploying alertmanager to the new platform
+
+Date: 2018-11-06
+
+### Status
+
+Accepted
+
+### Context
+
+The Observe team is a part of the new platform team, which is building out kubernetes capability in GDS.
+
+There is a long-term goal that teams in GDS should avoid running bespoke infrastructure, specific to that team, so that any infrastructure we run is run in a common way and supportible by many people.
+
+We also have a desire to migrate off ECS.  ECS is painful for running alertmanager because:
+
+  - ECS doesn't support dropping configuration files in place
+  - ECS doesn't support exposing multiple ports via load balancer for service discovery
+
+Kubernetes does not have either of these limitations.
+
+Currently, we have a plan to migrate everything to EC2, in order to get away from ECS.  We have quite a bit of outstanding pain from the old way of doing things:
+
+  - we have two different deploy processes; one using the Makefile and one using the deploy_enclave.sh
+  - we have two different code styles, related to the above
+  - we have two different types of infrastructure
+
+We haven't fully planned out how we would migrate alertmanager to EC2, but we suspect it would involve at least the following tasks:
+
+  - create a way of provisioning an EC2 instance with alertmanager installed (probably a stock ubuntu AMI with cloud.conf to install software)
+  - create a way of deploying that instance with configuration added (probably a terraform module similar to what we have for prometheus)
+  - actually deploy some alertmanagers to EC2 in parallel with ECS
+  - migrate prometheus to start using both EC2 and ECS alertmanagers in parallel
+  - once we're confident, switch off the ECS alertmanagers
+  - tidy up the old ECS alertmanager code
+
+This feels like a lot of work, especially if our longer-term goal is that we shouldn't run bespoke infrastructure and should instead run in some common way such as the new platform.
+
+Nevertheless, we could leave alertmanager in ECS but still ease some of the pain by refactoring the terraform code to be the new module-style instead of the old project-and-Makefile style, even if we leave alertmanager itself in ECS.
+
+(Prometheus is different: we want to run prometheus the same way that non-PaaS teams such as Verify or Pay run it, so that we can offer guidance to them. The principle is the same: we want to run things the same way other GDS teams run them.)
+
+### Decision
+
+1. We will pause any work migrating alertmanager to EC2
+2. We will run an alertmanager in the new platform, leaving the remaining alertmanagers in ECS
+3. We will try to migrate as much of nginx out of ECS as possible; in particular, we want paas-proxy to move to the same network (possibly same EC2 instance) as prometheus.
+4. We will refactor our terraform for ECS to be module-based rather than the old project-and-Makefile style, so that we reduce the different types of code and deployment style.
+5. We will keep prometheus running in EC2 and not migrate it to the new platform (although new platform environments will each have a prometheus available to them)
+
+### Consequences
+
+We will have to be careful to keep alertmanager configuration in sync between the old and new infrascture.
+
+We will have to keep our ECS instances running longer than we might otherwise choose to.

--- a/source/documentation/architecture/decisions/header.md
+++ b/source/documentation/architecture/decisions/header.md
@@ -1,0 +1,1 @@
+## Architectural Decisions

--- a/source/documentation/prometheus-for-paas-support.md
+++ b/source/documentation/prometheus-for-paas-support.md
@@ -1,12 +1,12 @@
-## Observe interruptible support
+## Prometheus for PaaS interruptible support
 
-Observe build and operate a Prometheus service for PaaS tenants, and are responsible for the ongoing business as usual Logit tasks.
+Automate operate a Prometheus service for PaaS tenants, and are responsible for the ongoing business as usual Logit tasks.
 
 ### Support availability
 
-The observe team are offering an in work hours support, this is currently 9am - 6pm, Monday to Fridays. Any issues out of hours will be recorded and handled during work hours.
+The automate team are offering an in work hours support, this is currently 9am - 6pm, Monday to Fridays. Any issues out of hours will be recorded and handled during work hours.
 
-### Observe interruptible tasks
+### Interruptible tasks related to Prometheus for PaaS
 - Keep interruptible Documentation Up To Date
 - Respond to PagerDuty alerts
 - Support users on the `#re-prometheus-support` and `#reliability-eng` slack channels
@@ -61,7 +61,7 @@ This information is important so that we can feedback and improve the process.
 When triaging an issue you should take some time to ask the following questions:
 
 - is someone else already looking at the issue
-  - slack the `#re-observe` channel, ask the team and look at existing Trello cards.
+  - slack the `#re-autom8` channel, ask the team and look at existing Trello cards.
 - what impact is it having on tenants:
   - High - does it affect their services, i.e. cause problems with deployments, affects performance of their apps.
   - Mid - does it impact their metrics collection, i.e. see unexpected gaps in metrics, or odd values, loss of historical metrics.
@@ -85,18 +85,6 @@ Talk to the team and decide who is going to be responsible for fixing the issue.
 - Gather and preserve evidence.
 - Resolution, update initiators that issue has been resolved.
 - Closure, organise a team incident review.
-
-### Handover process
-
-The [interruptible rota](https://governmentdigitalservice.pagerduty.com/schedules#PK5DYDY) runs from Tuesday to Tuesday, handover should take place after stand up.
-
-- Update the slack channels `#re-prometheus-support` and `#reliability-eng`:
-  - topic with your slack handle (and name if it's not clear in your handle)
-  - notification preferences so that you are aware of all communications on those channels.
-- Handover of any outstanding tasks:
-  - The plan to resolve the page / ticket.
-  - Actions taken, remaining and next step.
-  - Share relevant conversation threads or contacts if a conversation hasn't started.
 
 ## Alerts
 

--- a/source/observe-support.html.md.erb
+++ b/source/observe-support.html.md.erb
@@ -1,8 +1,0 @@
----
-title: "Observe Support"
-weight: 7
----
-
-# <%= current_page.data.title %>
-
-<%= partial 'documentation/observe-support.md' %>

--- a/source/prometheus-for-gds-paas-users.html.md.erb
+++ b/source/prometheus-for-gds-paas-users.html.md.erb
@@ -1,10 +1,13 @@
 ---
-title: "Architectural Decisions"
+title: "Prometheus for GDS PaaS Users"
 weight: 4
 ---
 
 # <%= current_page.data.title %>
 
+<%= partial 'documentation/prometheus-for-paas-support.md' %>
+
+<%= partial 'documentation/architecture/decisions/header.md' %>
 <%= partial 'documentation/architecture/decisions/0001-environments.md' %>
 <%= partial 'documentation/architecture/decisions/0002-configuration-management.md' %>
 <%= partial 'documentation/architecture/decisions/0003-use-ecs-for-initial-beta-buildout.md' %>


### PR DESCRIPTION
This better reflects the team structure going into next quarter

This Pr also moves the Architectural decision records from monitoring-doc which means that we can archive the monitoring doc

https://trello.com/c/6a84sEpd/803-migrate-adrs-to-re-team-manual
https://trello.com/c/loV2aljk/804-create-rename-re-team-manual-section-for-prometheus-for-gds-paas-users

This necessitates some changes to the alert config 
https://github.com/alphagov/prometheus-aws-configuration-beta/pull/255