### PR TITLE
Remove all references to the recently deprecated RE Jenkins

### DIFF
--- a/source/documentation/using-re-jenkins.md
+++ b/source/documentation/using-re-jenkins.md
@@ -1,9 +1,0 @@
-### A secure and simple Jenkins template
-
-We provide the Terraform template to provision a secure and easy to use Jenkins platform.
-
-You can find the documentation in the [repository itself](https://github.com/alphagov/re-build-systems). In particular, consult the main `README` file and the `docs` folder.
-
-### Jenkins for the TechOps teams
-
-There is an instance of the platform running for teams in TechOps. That can be found [here](https://prod.gds-re.build.gds-reliability.engineering). The repository with its configuration can be found [here](https://github.com/alphagov/re-build-terraform).

--- a/source/using-re-jenkins.html.md.erb
+++ b/source/using-re-jenkins.html.md.erb
@@ -1,8 +1,0 @@
----
-title: "Using Build Tools"
-weight: 5
----
-
-# <%= current_page.data.title %>
-
-<%= partial 'documentation/using-re-jenkins.md' %>


### PR DESCRIPTION
Jenkins within RE has been deprecated.  This PR removes documentation mentioning its use.