### PR TITLE
Notify support documentation

### DIFF
--- a/source/documentation/notify.md
+++ b/source/documentation/notify.md
@@ -25,7 +25,7 @@ Notify has three dashboards:
 
 ### CloudWatch dashboards
 
-**Prerequisites: the [GDS CLI](https://github.com/alphagov/gds-cli) and [YubiKey](https://re-team-manual.cloudapps.digital/yubikeys.html#yubikeys) setup are required to access CloudWatch metrics.** 
+**Note: having [GDS CLI](https://github.com/alphagov/gds-cli) and [YubiKey](https://re-team-manual.cloudapps.digital/yubikeys.html#yubikeys) set up makes it easier to access CloudWatch metrics, though it is not required. The dashboards can be accessed in the AWS console.** 
 
 Once GDS CLI and YubiKey configuration is set up, open a new terminal window and run:
 

--- a/source/documentation/notify.md
+++ b/source/documentation/notify.md
@@ -25,7 +25,7 @@ Notify has three dashboards:
 
 ### CloudWatch dashboards
 
-**The [GDS CLI](https://github.com/alphagov/gds-cli) and [YubiKey](https://re-team-manual.cloudapps.digital/yubikeys.html#yubikeys) setup are required to access CloudWatch metrics.** 
+**Prerequisites: the [GDS CLI](https://github.com/alphagov/gds-cli) and [YubiKey](https://re-team-manual.cloudapps.digital/yubikeys.html#yubikeys) setup are required to access CloudWatch metrics.** 
 
 Once GDS CLI and YubiKey configuration is set up, open a new terminal window and run:
 
@@ -53,7 +53,7 @@ Follow the accessing [CloudWatch dashboards](#cloudwatch-dashboards) instruction
 
 ## Testing SMS and Email
 
-**A Notify Admin account is required to test SMS and email notifications.**
+**Prerequisites: a Notify Admin account is required to test SMS and email notifications.**
 
 Once SC clearance is passed, a member of the RE-Portfolio team will set up the necessary Notify Admin account. 
 

--- a/source/documentation/notify.md
+++ b/source/documentation/notify.md
@@ -1,4 +1,41 @@
-## Accessing Dashboards
+## Accessing Metrics
+
+Notify uses [Grafana](https://grafana.com/) for displaying metrics  and [Prometheus](https://prometheus.io/) for metric collection on its PaaS infrastructure. 
+
+The RE-Team Manual has a section on [Prometheus For GDS PaaS Users](https://re-team-manual.cloudapps.digital/prometheus-for-gds-paas-users.html#content) which outlines the monitoring and alerting service for GDS PaaS tenants.
+
+Notify also uses [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html) metrics for its infrastructure components in AWS.
+
+### Grafana
+
+Accessing Notify's Grafana dashboards:
+
+1. Navigate to PaaS's central Grafana account: [grafana-paas.cloudapps.digital](https://grafana-paas.cloudapps.digital).
+2. Choose the "Sign in with Google" login option to authenticate via a GDS email account.
+3. From the "Home Copy" dropdown, select "Notify" to view the available Notify dashboards.
+
+Notify has three dashboards: 
+
+- [Document Download](https://grafana-paas.cloudapps.digital/d/FwXIHjiiz)
+
+- [Notify Apps](https://grafana-paas.cloudapps.digital/d/aCYK0WDik)
+
+- [Postgres](https://grafana-paas.cloudapps.digital/d/SYlv1gAmz)
+
+
+### CloudWatch
+
+**The GDS CLI and [YubiKey](https://re-team-manual.cloudapps.digital/yubikeys.html#yubikeys) setup are required to access CloudWatch metrics.** 
+
+Once GDS CLI and YubiKey configuration is set up, open a new terminal window and run:
+
+```
+$ gds aws <some-notify-service>
+```
+
+This command will prompt a GPG key sign-in process.
+
+On successful sign in, a browser window will open on the Notify service CloudWatch landing page.
 
 ## Checking Logs
 

--- a/source/documentation/notify.md
+++ b/source/documentation/notify.md
@@ -33,7 +33,7 @@ Once GDS CLI and YubiKey configuration is set up, open a new terminal window and
 $ gds aws <some-notify-service>
 ```
 
-This command will prompt a GPG key sign-in process.
+This command will prompt a sign-in process with the use of MFA stored on a YubiKey.
 
 On successful sign in, a browser window will open on the Notify service CloudWatch landing page.
 

--- a/source/documentation/notify.md
+++ b/source/documentation/notify.md
@@ -62,8 +62,7 @@ Once SC clearance is passed, a member of the RE-Portfolio team will set up the n
 1. Navigate to GOV.UK Notify's [notifications.service.gov.uk](https://www.notifications.service.gov.uk/sign-in).
 2. Enter GDS email and account password to sign in.
 3. On successful signin, the browser will redirect to the "Check your phone" page **and** an automatic SMS will be sent to the user.
-4. Use the SMS code to complete the sign in process.
-5. 
+4. Use the SMS code to complete the sign in process and verify SMS notifications work.
 
 ### Testing email
 

--- a/source/documentation/notify.md
+++ b/source/documentation/notify.md
@@ -78,6 +78,16 @@ Once SC clearance is passed, a member of the RE-Portfolio team will set up the n
 
 ## Rolling AMIs
 
+Instructions for rolling AMIs can be found in the [notifications-aws repo](https://github.com/alphagov/notifications-aws).
+
+Once changes have been made to the AMI, run the [Packer documentation instructions](https://github.com/alphagov/notifications-aws/blob/master/packer/README.md) and then the [Terraform documentation instructions](https://github.com/alphagov/notifications-aws/blob/master/terraform/README.md). 
+
+These instructions will be automated by Concourse. 
+
 ## Running Ansible
+
+Notify uses [Ansible](https://docs.ansible.com/) to configure Jenkins, create Packer images, and manage applications.
+
+The notifications-aws Ansible [documentation](https://github.com/alphagov/notifications-aws/blob/master/ansible/README.md) contains instructions on how to run Ansible playbooks
 
 ## Using CloudFoundary

--- a/source/documentation/notify.md
+++ b/source/documentation/notify.md
@@ -6,7 +6,7 @@ The RE-Team Manual has a section on [Prometheus For GDS PaaS Users](https://re-t
 
 Notify also uses [CloudWatch](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/WhatIsCloudWatch.html) metrics for its infrastructure components in AWS.
 
-### Grafana
+### Grafana dashboards
 
 Accessing Notify's Grafana dashboards:
 
@@ -23,7 +23,7 @@ Notify has three dashboards:
 - [Postgres](https://grafana-paas.cloudapps.digital/d/SYlv1gAmz)
 
 
-### CloudWatch
+### CloudWatch dashboards
 
 **The GDS CLI and [YubiKey](https://re-team-manual.cloudapps.digital/yubikeys.html#yubikeys) setup are required to access CloudWatch metrics.** 
 
@@ -38,6 +38,18 @@ This command will prompt a GPG key sign-in process.
 On successful sign in, a browser window will open on the Notify service CloudWatch landing page.
 
 ## Checking Logs
+
+Notify uses [Kibana](https://www.elastic.co/products/kibana) for collecting application logs and CloudWatch for logs related to its AWS infrastructure.
+
+System logs for infrastructure in PaaS can be accessed by creating a support ticket with the PaaS team.
+
+### Kibana
+
+Follow the RE Team Manual's ["Getting started with Logit"](https://reliability-engineering.cloudapps.digital/logging.html#content) instructions to access Kibana logs.
+
+### CloudWatch
+
+Follow the accessing [CloudWatch dashboards](#cloudwatch-dashboards) instructions.
 
 ## Testing SMS and Email
 

--- a/source/documentation/notify.md
+++ b/source/documentation/notify.md
@@ -53,7 +53,7 @@ Follow the accessing [CloudWatch dashboards](#cloudwatch-dashboards) instruction
 
 ## Testing SMS and Email
 
-**Prerequisites: a Notify Admin account is required to test SMS and email notifications.**
+**Prerequisites: an account on Notifications admin portal with access to any organisation is required to test SMS and email notifications.**
 
 Once SC clearance is passed, a member of the RE-Portfolio team will set up the necessary Notify Admin account. 
 

--- a/source/documentation/notify.md
+++ b/source/documentation/notify.md
@@ -1,0 +1,11 @@
+## Accessing Dashboards
+
+## Checking Logs
+
+## Testing SMS and Email
+
+## Rolling AMIs
+
+## Running Ansible
+
+## Using CloudFoundary

--- a/source/documentation/notify.md
+++ b/source/documentation/notify.md
@@ -89,5 +89,3 @@ These instructions will be automated by Concourse.
 Notify uses [Ansible](https://docs.ansible.com/) to configure Jenkins, create Packer images, and manage applications.
 
 The notifications-aws Ansible [documentation](https://github.com/alphagov/notifications-aws/blob/master/ansible/README.md) contains instructions on how to run Ansible playbooks
-
-## Using CloudFoundary

--- a/source/documentation/notify.md
+++ b/source/documentation/notify.md
@@ -53,6 +53,30 @@ Follow the accessing [CloudWatch dashboards](#cloudwatch-dashboards) instruction
 
 ## Testing SMS and Email
 
+**A Notify Admin account is required to test SMS and email notifications.**
+
+Once SC clearance is passed, a member of the RE-Portfolio team will set up the necessary Notify Admin account. 
+
+### Testing SMS:
+
+1. Navigate to GOV.UK Notify's [notifications.service.gov.uk](https://www.notifications.service.gov.uk/sign-in).
+2. Enter GDS email and account password to sign in.
+3. On successful signin, the browser will redirect to the "Check your phone" page **and** an automatic SMS will be sent to the user.
+4. Use the SMS code to complete the sign in process.
+5. 
+
+### Testing email
+
+1. Navigate and sign in to [notifications.service.gov.uk](https://www.notifications.service.gov.uk/sign-in).
+2. Choose the desired service to check.
+3. From the sidebar, choose the "Templates" option.
+4. Choose an email template from the list.
+5. Click "Send".
+6. Configure where the user's reply will arrive (e.g. govwifi-support) – this is often pre-populated in the template.
+7. Configure the target email (where the email will be sent, e.g., your GDS email).
+8. Preview and approve.
+9. Check the target email account to verify an email has arrived.
+
 ## Rolling AMIs
 
 ## Running Ansible

--- a/source/documentation/notify.md
+++ b/source/documentation/notify.md
@@ -25,7 +25,7 @@ Notify has three dashboards:
 
 ### CloudWatch dashboards
 
-**The GDS CLI and [YubiKey](https://re-team-manual.cloudapps.digital/yubikeys.html#yubikeys) setup are required to access CloudWatch metrics.** 
+**The [GDS CLI](https://github.com/alphagov/gds-cli) and [YubiKey](https://re-team-manual.cloudapps.digital/yubikeys.html#yubikeys) setup are required to access CloudWatch metrics.** 
 
 Once GDS CLI and YubiKey configuration is set up, open a new terminal window and run:
 

--- a/source/notify.html.md.erb
+++ b/source/notify.html.md.erb
@@ -1,0 +1,8 @@
+---
+title: "GOV.UK Notify"
+weight: 8
+---
+
+# <%= current_page.data.title %>
+
+<%= partial 'documentation/notify.md' %>


### PR DESCRIPTION
### WHAT
Documents a base set of tasks for supporting Notify:

* Accessing metrics
* Accessing logs
* Testing email/sms
* Rolling AMIs
* Running Ansible

The documentation is an expanded form of the notes I took at the [Notify Game Day session](https://hackmd.cloudapps.digital/SkCAz-KFT3qGFT5QaSybkw).