### PR TITLE
YubiKey: Specify how to generate 4096-bit GPG keys

### DIFF
--- a/source/documentation/yubikeys.md
+++ b/source/documentation/yubikeys.md
@@ -70,6 +70,8 @@ Follow these steps to setup the GPG on your YubiKey.
 1. Open Terminal.
 1. Enter the GPG command: `gpg --card-edit`
 1. At the `gpg/card>` prompt, enter the command: `admin`
+1. Enter the command: `key-attr`, then select option 1 (`RSA`) and
+   type `4096` when asked for key strength
 1. Enter the command: `generate`
 1. When prompted, specify if you want to make an off-card backup of your
    encryption key. We recommend that you say `no`. It brings no value.


### PR DESCRIPTION
- GOV.UK are starting to use Yubikeys (:tada:) for GPG and SSH keys.
- Turns out that this guide uses the defaults (2048), which, when people
  use the authentication key portion for SSH add add it to GOV.UK's Puppet
  repo, [CI checks fail due to low key
  strength](https://github.com/alphagov/govuk-puppet/blob/b588e4ade996e97b8975e69cb00800521fff4a48/modules/users/spec/classes/users_spec.rb#L43-L61).