### PR TITLE
Replace rsa2048 with rsa4096 in Key ID instructions

### DIFF
--- a/source/documentation/yubikeys.md
+++ b/source/documentation/yubikeys.md
@@ -101,7 +101,7 @@ Follow these steps to setup the GPG on your YubiKey.
     ```
     gpg -K --keyid-format 0xLONG
     ```
-    - `Key ID` is the 18 character string after `rsa2048/` on the first line of
+    - `Key ID` is the 18 character string after `rsa4096/` on the first line of
       the output.
     - `Key fingerprint` (if present) is the 40 character string in the
       second line of the output.


### PR DESCRIPTION
To be consistent with earlier instructions to use a key strength of
4096, update the instructions for publishing the public key to reference
`rsa4096` rather than `rsa2048`.