### PR TITLE
Remove references to Concourse pipelines that are now automagically generated

### DIFF
--- a/source/documentation/automate-on-call-interruptible.md
+++ b/source/documentation/automate-on-call-interruptible.md
@@ -254,13 +254,6 @@ These are requested by PR in the `tech-ops-private` repository, which is availab
     * In addition to `owners` and `members`, `pipeline_operators` and `viewers` may be specified.
     * Set the `desired_capacity` attribute of the `concourse-worker-pool` module as appropriate, and optionally set the `instance_type` attribute too (default is `t3.small`).
     * By default every team's workers runs in the same subnet and gets the same egress IP. Where it is a requirement that egress IPs be used only by a specific team, that team may be given its own subnet and NAT Gateway, as is done for e.g. the `gsp` team. We do not do this purely for AWS Role SourceIp Conditions, as the Principal will already be unique to the right team's worker group. They may be provided for cases like SSH. These cost more money.
-* Create a new job in the roll-instances pipeline in `reliability-engineering/terraform/deployments/gds-tech-ops/cd-main/pipelines/roll-instances.yml`
-    * Copy an existing one
-    * Update the `TEAM` param and the name of the job
-    * Set `MINIMUM_HEALTHY` as appropriate - this is passed into `awsc`'s `--min-healthy-percent` parameter. If the team has multiple worker nodes it can be set above 0%.
-* Update `reliability-engineering/terraform/deployments/gds-tech-ops/cd/deploy-info-pipelines.yml`
-    * Copy an existing team in the `pipeline` resource source, change the `name` but leave `username` and `password` the same.
-    * Copy an existing `put` step in the `deploy-info-pipelines` job, change the `team` but leave the `name` and `config_file` the same.
 
 Then when reviewing such requests, ensure they are sized appropriately and don't include a new subnet where they don't need to. Ensure the permissions are set up correctly and the requesting team knows the implications of the permissions chosen. It will be continuously deployed by the [deploy](https://cd.gds-reliability.engineering/teams/main/pipelines/deploy) pipeline, after passing through the staging deployment.
 


### PR DESCRIPTION
Following https://github.com/alphagov/tech-ops/pull/138 and co.