### PR TITLE
Update alertmanager documentation to match new ALB

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,67 @@
+{
+  "custom_plugin_paths": [],
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2020-08-17T14:02:59Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {},
+  "version": "0.14.2",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/source/documentation/prometheus-for-gds-paas/index.md.erb
+++ b/source/documentation/prometheus-for-gds-paas/index.md.erb
@@ -37,26 +37,30 @@ Figure 1: Architecture for components hosted on AWS
 ![Architecture](../../images/alertmanager.svg)
 
 Three instances of Alertmanager are deployed over three AWS availability zones in Ireland (eu-west-1) for resilience and high availability.
-Alertmanager has three public IPs, all on a single name [[alerts][]]
+If you want to browse Alertmanager as a human, go here: [[alerts][]]
 
-- There are multiple DNS A records, one for each alertmanager
-  instance.  Prometheus servers can use this name with
-  `dns_sd_configs` to automatically discover all the alertmanagers.
-- You can access each IP address separately here:
+- You can access each alertmanager separately here:
   [[alerts-eu-west-1a][]] [[alerts-eu-west-1b][]]
   [[alerts-eu-west-1c][]]
 
-The public IPs for Alertmanager belong to an NLB.  There is one IP per
-availability zone.  The NLB performs same-zone load balancing: it
-routes traffic to the Alertmanager instance in the same AZ as the
-public IP.  The inbound requests are also restricted to office IP
-addresses only.  The main purpose of the NLB is so that we can
-terminate TLS using a Certificate Manager certificate.
+If you want to configure Prometheus to talk to them, something like the following will work:
+
+```yaml
+  alertmanagers:
+  - scheme: https
+    static_configs:
+    - targets:
+      - alerts-eu-west-1a.monitoring.gds-reliability.engineering
+      - alerts-eu-west-1b.monitoring.gds-reliability.engineering
+      - alerts-eu-west-1c.monitoring.gds-reliability.engineering
+```
 
 Alertmanager itself is run in ECS Fargate.
 
 - There is one ECS service per AZ, each of which runs a single task.
-- Each ECS service registers with the target group of the NLB.
+- Each ECS service registers with a separate per-AZ target group of
+  the ALB, and also with a single target group for all alertmanager
+  instances.
 - For [alertmanager clustering][]:
     - Each alertmanager task needs to talk to each other alertmanager
       task on port 9094


### PR DESCRIPTION
We've binned the old NLB and reverted back to the old old ALB design.