### PR TITLE
Accessibility fixes

### DIFF
--- a/source/documentation/prometheus-for-gds-paas/architecture/decisions/0002-configuration-management.md
+++ b/source/documentation/prometheus-for-gds-paas/architecture/decisions/0002-configuration-management.md
@@ -13,7 +13,7 @@ actively developed.
 #### Context
 
 We have the requirement of adding some resources to the base cloud instances. We currently do
-this via the [cloud.conf](https://github.com/alphagov/prometheus-aws-configuration/blob/375f34600e373aa0e4c66fcae032ceee361d8c21/terraform/modules/prometheus/cloud.conf) system. This presents us with some limitations, such as configuration
+this using the [cloud.conf](https://github.com/alphagov/prometheus-aws-configuration/blob/375f34600e373aa0e4c66fcae032ceee361d8c21/terraform/modules/prometheus/cloud.conf) system. This presents us with some limitations, such as configuration
 being limited to 16kb, duplication in each instance terraform and a lack of fast feedback testing.
 
 #### Decision
@@ -30,5 +30,5 @@ Our puppet manifests can be reused both within tools and possibly other programs
 
 It's worth noting we will still need a basic cloud.conf file to install and run the puppet agent but this
 will be minimal and reusable in each of our terraform projects. There is also the risk that people will
-put more in the puppet code than they should. This will be remediated via review of
+put more in the puppet code than they should. This will be remediated by review of
 architecture and code.

--- a/source/documentation/prometheus-for-gds-paas/architecture/decisions/0003-use-ecs-for-initial-beta-buildout.md
+++ b/source/documentation/prometheus-for-gds-paas/architecture/decisions/0003-use-ecs-for-initial-beta-buildout.md
@@ -15,7 +15,7 @@ covered in ADR #12.
 #### Context
 
 Existing self-hosted infrastructure at GDS has been managed in code
-using tools like puppet, but in a somewhat ad hoc way with each team
+using tools like puppet, but in a somewhat unplanned way with each team
 doing things differently, little sharing of code, and much reinvention
 of wheels.  We would like to learn about other ways of deploying
 infrastructure which encourage consistency: in terms of code

--- a/source/documentation/prometheus-for-gds-paas/architecture/decisions/0004-cloudwatch-metrics.md
+++ b/source/documentation/prometheus-for-gds-paas/architecture/decisions/0004-cloudwatch-metrics.md
@@ -8,7 +8,7 @@ Accepted.
 
 #### Context
 
-We wanted to gather metrics from our own infrastructure so that we can drive alerts when things go wrong. Amazon exposes platform-level metrics via CloudWatch.
+We wanted to gather metrics from our own infrastructure so that we can drive alerts when things go wrong. Amazon exposes platform-level metrics through CloudWatch.
 Prometheus provides a [cloudwatch_exporter](https://github.com/prometheus/cloudwatch_exporter) which makes these metrics available to prometheus.
 
 We had a [spike](https://github.com/alphagov/prometheus-aws-configuration-beta/tree/cloudwatch) to see if we could use the Cloudwatch exporter to get Cloudwatch metrics and trigger alerts.
@@ -26,8 +26,8 @@ Based on a simple assumption of 100 metrics requested, being scraped once every 
 
 `100 x 6 x 24 x 365 x $0.00001 x 10 = $525.6 per year`
 
-However if we wish to scrape at the same rate we would a normal target, e.g. 30
-seconds that would become roughly $10,500 per year.
+However if we wish to scrape at the same rate we would a normal target, for example 30
+seconds, that would become roughly $10,500 per year.
 
 100 metrics also appears to be unlikely. Based on asking for just these ALB and EBS
 metrics:
@@ -46,8 +46,8 @@ we appear to be requesting roughly 4000 metrics per scrape. If we scraped our cu
 
 By requesting only ALB metrics in the dev accounts, we still produce about 160 API requests according to the `cloudwatch_requests_total` counter for each scrape. Somewhat strangely, this only returns about 30 timeseries so we are not sure if our config is incorrect and if the number of API calls could be reduced to closer match the number of timeseries.
 
-Note, as dev accounts have lots of resources e.g. volumes, there may be fewer
-metrics requested for staging and prod as unlike the dev account we wouldn't be
+Note, as dev accounts have lots of resources, for example volumes, there may be fewer
+metrics requested for staging and prod as unlike the dev account we would not be
 exporting metrics for other stacks.
 
 It takes a long time to get a response from the /metrics endpoint as it needs to make many API calls. This causes slow response times for which our prometheus scrape config needs to allow for using the `scrape_timeout` setting.
@@ -76,6 +76,6 @@ This has however been fixed in [this commit](https://github.com/alphagov/prometh
 
 No alert is raised but the failure is no longer silent as Prometheus will no longer run without an attached EBS volume.
 
-We also don't have metrics available for ALBs and other parts of our AWS infrastructure.
+We also do not have metrics available for ALBs and other parts of our AWS infrastructure.
 
 We need to explore other solutions to get these metrics that are more cost-efficient.

--- a/source/documentation/prometheus-for-gds-paas/architecture/decisions/0006-deploying-prometheus-to-private-networks-in-aws.md
+++ b/source/documentation/prometheus-for-gds-paas/architecture/decisions/0006-deploying-prometheus-to-private-networks-in-aws.md
@@ -23,9 +23,9 @@ Our existing prometheus infrastructure (for PaaS teams) works by using
 our [service broker][] to generate file_sd_configs which prometheus
 then uses to scrape PaaS apps over the public internet.
 
-This approach won't work for non-PaaS teams, because it's based on an
+This approach will not work for non-PaaS teams, because it's based on an
 assumption – that every app is directly routable from the public
-internet – that doesn't hold in non-PaaS environments.  Instead, apps
+internet – that does not hold in non-PaaS environments.  Instead, apps
 live on private networks and public access is controlled by firewalls
 and load balancers.
 
@@ -36,7 +36,7 @@ and load balancers.
 As the previous section explained, our main problem is that we want a
 prometheus (provided by us) to be able to scrape apps and other
 endpoints (owned by the client team, and living on a private network).
-We want to do this in a way which doesn't require clients to
+We want to do this in a way which does not require clients to
 unnecessarily expose metrics endpoints to the public internet.
 
 Some other things we would like to be able to do are:
@@ -72,7 +72,7 @@ The artefact we provide could take several forms:
  - a terraform module which the client team includes in their own
    terraform project
 
-This model has the downside that it doesn't allow us to maintain
+This model has the downside that it does not allow us to maintain
 prometheus at a single common version, because we are at the mercy of
 client teams' deploy cadences to ensure things get upgraded.
 
@@ -146,7 +146,7 @@ peering connections to maintain.
 
 As RE (and techops more broadly) provides more services, client teams
 end up having to consider more VPC Peering connections in their
-security analyses, and this doesn't feel like a particularly scalable
+security analyses, and this does not feel like a particularly scalable
 way for us to offer services to client teams.
 
 Finally, we believe that VPC Peering is something that has to be
@@ -176,7 +176,7 @@ In this scenario, we would build a single prometheus in its own VPC
 for each client team VPC we offer the service to.
 
 This avoids some of the drawbacks of the previous case, in that the
-prometheus doesn't have privileges to access multiple separate VPCs.
+prometheus does not have privileges to access multiple separate VPCs.
 
 [VPC Peering]: https://docs.aws.amazon.com/AmazonVPC/latest/PeeringGuide/Welcome.html
 
@@ -224,7 +224,7 @@ However it has some drawbacks:
 
 #### Consequences
 
-We haven't yet solved the problem of how client teams provide alert
+We have not yet solved the problem of how client teams provide alert
 configuration to prometheus.
 
 For the moment, it is acceptable to define configuration in

--- a/source/documentation/prometheus-for-gds-paas/architecture/decisions/0008-use-of-verify-egress-proxies.md
+++ b/source/documentation/prometheus-for-gds-paas/architecture/decisions/0008-use-of-verify-egress-proxies.md
@@ -10,8 +10,8 @@ Accepted
 
 Verify employ egress proxies to control access to external resources.
 These are a security measure to help prevent data from being exfiltrated from within Verify.
-The Prometheus server will need access to external resources, notibly an Ubuntu APT mirror during the bootstrap process.
-The Prometheus server should not setup it's own routes to bypass the egress proxy i.e. use a NAT gateway or Elastic IP, as this will potentially open up a route for data exfiltration.
+The Prometheus server will need access to external resources, notably an Ubuntu APT mirror during the bootstrap process.
+The Prometheus server should not set up its own routes to bypass the egress proxy by using a NAT gateway or Elastic IP, as this will potentially open up a route for data exfiltration.
 
 #### Decision
 

--- a/source/documentation/prometheus-for-gds-paas/architecture/decisions/0011-sli-for-how-reliably-do-we-deliver-pages.md
+++ b/source/documentation/prometheus-for-gds-paas/architecture/decisions/0011-sli-for-how-reliably-do-we-deliver-pages.md
@@ -36,7 +36,7 @@ We came up with:
 
 We think that from here we can use the `increase` function to tell us how many times alerts have begun firing. To use this we think we would need to use recording rules as per https://www.robustperception.io/composing-range-vector-functions-in-promql to turn our query into a single range vector.
 
-At that point we should have a number for how many alerts have begun firing in a given time period. However we are not confident that this number is equal to the number of pagerduty incidents we expect to be created. The reason for this is because Alertmanager [groups firing alerts](https://prometheus.io/docs/alerting/alertmanager/#grouping), meaning multiple firing alerts may only result in one notification and therefore one incident. A potential way around this would be to try and edit the grouping behaviour of Alertmanager using it's config but it [doesn't look it's possible to turn it off completely](https://groups.google.com/forum/#!topic/prometheus-users/35znfrwu_z8). There could also be issues if an alert fires, then resolves itself, and then fires immediately after only triggering an single incident.
+At that point we should have a number for how many alerts have begun firing in a given time period. However we are not confident that this number is equal to the number of pagerduty incidents we expect to be created. The reason for this is because Alertmanager [groups firing alerts](https://prometheus.io/docs/alerting/alertmanager/#grouping), meaning multiple firing alerts may only result in one notification and therefore one incident. A potential way around this would be to try and edit the grouping behaviour of Alertmanager using it's config but it [does not look it's possible to turn it off completely](https://groups.google.com/forum/#!topic/prometheus-users/35znfrwu_z8). There could also be issues if an alert fires, then resolves itself, and then fires immediately after only triggering an single incident.
 
 #### Decision
 
@@ -44,4 +44,4 @@ We have decided not to try and implement this SLI at the moment as we are not co
 
 #### Consequences
 
-We do not measure one of our main user journeys accurately and thus can't alert if there are problems with it. We may instead have to use a proxy or measure individual components that make up the user journey instead which may be easier to measure but less accurate.
+We do not measure one of our main user journeys accurately and thus cannot alert if there are problems with it. We may instead have to use a proxy or measure individual components that make up the user journey instead which may be easier to measure but less accurate.

--- a/source/documentation/prometheus-for-gds-paas/architecture/decisions/0012-deploy-alertmanager-to-k8s.md
+++ b/source/documentation/prometheus-for-gds-paas/architecture/decisions/0012-deploy-alertmanager-to-k8s.md
@@ -14,8 +14,8 @@ There is a long-term goal that teams in GDS should avoid running bespoke infrast
 
 We also have a desire to migrate off ECS.  ECS is painful for running alertmanager because:
 
-  - ECS doesn't support dropping configuration files in place
-  - ECS doesn't support exposing multiple ports via load balancer for service discovery
+  - ECS does not support dropping configuration files in place
+  - ECS does not support exposing multiple ports using load balancer for service discovery
 
 Kubernetes does not have either of these limitations.
 
@@ -25,7 +25,7 @@ Currently, we have a plan to migrate everything to EC2, in order to get away fro
   - we have two different code styles, related to the above
   - we have two different types of infrastructure
 
-We haven't fully planned out how we would migrate alertmanager to EC2, but we suspect it would involve at least the following tasks:
+We have not fully planned out how we would migrate alertmanager to EC2, but we suspect it would involve at least the following tasks:
 
   - create a way of provisioning an EC2 instance with alertmanager installed (probably a stock ubuntu AMI with cloud.conf to install software)
   - create a way of deploying that instance with configuration added (probably a terraform module similar to what we have for prometheus)
@@ -34,7 +34,7 @@ We haven't fully planned out how we would migrate alertmanager to EC2, but we su
   - once we're confident, switch off the ECS alertmanagers
   - tidy up the old ECS alertmanager code
 
-This feels like a lot of work, especially if our longer-term goal is that we shouldn't run bespoke infrastructure and should instead run in some common way such as the new platform.
+This feels like a lot of work, especially if our longer-term goal is that we should not run bespoke infrastructure and should instead run in some common way such as the new platform.
 
 Nevertheless, we could leave alertmanager in ECS but still ease some of the pain by refactoring the terraform code to be the new module-style instead of the old project-and-Makefile style, even if we leave alertmanager itself in ECS.
 

--- a/source/documentation/prometheus-for-gds-paas/index.md.erb
+++ b/source/documentation/prometheus-for-gds-paas/index.md.erb
@@ -15,7 +15,10 @@ Figure 1: Architecture for components hosted on AWS
 - Three instances of Prometheus are deployed over three AWS
   availability zones in Ireland (eu-west-1) for resilience and high
   availability (figure 1).
-- URLs for these instances are: [[prom-1][]] [[prom-2][]] [[prom-3][]]
+- URLs for these instances are:
+  - [https://prom-1.monitoring.gds-reliability.engineering/](https://prom-1.monitoring.gds-reliability.engineering/)
+  - [https://prom-2.monitoring.gds-reliability.engineering/](https://prom-2.monitoring.gds-reliability.engineering/)
+  - [https://prom-3.monitoring.gds-reliability.engineering/](https://prom-3.monitoring.gds-reliability.engineering/)
 
 - Each Prometheus instance has its own persistent EBS storage. Each instance is independent to each other and scrapes metrics separately.
 - The three Prometheis are not load balanced and each have their own public URL, routed by the ALB according to the request URL (prom-1, prom-2, prom-3)
@@ -23,12 +26,8 @@ Figure 1: Architecture for components hosted on AWS
 - Each Prometheus sends their alerts to all three of the Alertmanagers.
 - Configuration for Prometheus is provided in YAML files which are
   stored in an S3 bucket.
-- Changes to the [configuration][prometheus-aws-configuration-beta] are continuously deployed via the [prometheus pipeline][].
+- Changes to the [configuration][prometheus-aws-configuration-beta] are continuously deployed through the [prometheus pipeline][].
 
-
-[prom-1]: https://prom-1.monitoring.gds-reliability.engineering/
-[prom-2]: https://prom-2.monitoring.gds-reliability.engineering/
-[prom-3]: https://prom-3.monitoring.gds-reliability.engineering/
 [prometheus-aws-configuration-beta]: https://github.com/alphagov/prometheus-aws-configuration-beta
 
 ### Alertmanager
@@ -37,11 +36,12 @@ Figure 1: Architecture for components hosted on AWS
 ![Architecture](../../images/alertmanager.svg)
 
 Three instances of Alertmanager are deployed over three AWS availability zones in Ireland (eu-west-1) for resilience and high availability.
-If you want to browse Alertmanager as a human, go here: [[alerts][]]
+If you want to browse Alertmanager as a human, go to [GDS Reliability Engineering Alerts Monitoring](https://alerts.monitoring.gds-reliability.engineering/#/alerts).
 
 - You can access each alertmanager separately here:
-  [[alerts-eu-west-1a][]] [[alerts-eu-west-1b][]]
-  [[alerts-eu-west-1c][]]
+  - [[alerts-eu-west-1a][]]
+  - [[alerts-eu-west-1b][]]
+  - [[alerts-eu-west-1c][]]
 
 If you want to configure Prometheus to talk to them, something like the following will work:
 
@@ -72,11 +72,11 @@ Alertmanager itself is run in ECS Fargate.
       to each alertmanager task to tell it to discover peers using
       this DNS name
 - Configuration for Alertmanager is provided in YAML files and
-  passed in via an environment variable in the task.  We override
+  passed in using an environment variable in the task.  We override
   the `entrypoint` of the container to save the environment variable
   into a file and pass the filename to alertmanager.
 
-Alertmanager is continuously deployed via the [prometheus pipeline][].
+Alertmanager is continuously deployed using the [prometheus pipeline][].
 
 [alerts]: https://alerts.monitoring.gds-reliability.engineering/#/alerts
 [alerts-eu-west-1a]: https://alerts-eu-west-1a.monitoring.gds-reliability.engineering/#/alerts
@@ -103,7 +103,7 @@ Figure 2: System boundary diagram for Prometheus for GDS PaaS - interaction with
 
 Figure 3: Interaction between PaaS tenants and Prometheus for GDS PaaS and service discovery
 
-- Tenants deploy [Prometheus exporters](#exporter) on PaaS to export container-level, app and service metrics on PaaS with */metrics* endpoints to be scraped.
+- Tenants deploy [Prometheus exporters](#exporter) on PaaS to export container-level, app and service metrics on PaaS with `/metrics` endpoints to be scraped.
 - Tenants create a service using the gds-prometheus service broker and bind apps to the service.
 - If the tenants wish to restrict the web requests with IP safelist, they can deploy the [ip-safelist route service](#safelist) and bind application routes to the service. This step is optional.
 - PaaS tenants can use the Prometheus GUI to query the metrics.
@@ -112,12 +112,12 @@ Figure 3: Interaction between PaaS tenants and Prometheus for GDS PaaS and servi
 
 ### Service discovery
 - Service discovery allows Prometheus for GDS PaaS to discover which [targets](https://prom-1.monitoring.gds-reliability.engineering/targets) on PaaS to scrape.
-- A service broker, named “gds-prometheus”, is available to GDS PaaS tenants (they can see it via `cf marketplace`) and is deployed from the [cf\_app\_discovery](https://github.com/alphagov/cf_app_discovery) code base .
+- A service broker, named “gds-prometheus”, is available to GDS PaaS tenants (they can see it using `cf marketplace`) and is deployed from the [cf\_app\_discovery](https://github.com/alphagov/cf_app_discovery) code base.
 - [cf\_app\_discovery](https://github.com/alphagov/cf_app_discovery) is an app written in Ruby, which is composed of two elements:
   - prometheus-service-broker: a Sinatra app that listens to calls made by the CloudFoundry service API when applications bind to or unbind from the service; and
   - prometheus-target-updater: a cron job that runs every five minutes to tell prometheus-service-broker to detect apps that have been stopped, scaled or killed
 - PaaS tenants create a service with the gds-prometheus service broker and bind the apps to the service.  This will register and update the targets to be scraped by Prometheus.
-- prometheus-service-broker writes JSON files to an S3 bucket which detail the target to monitor, target labels to use for the target, and the application guid which is used by the instrumentation libraries to protect the /metrics endpoint on the app via basic auth.
+- prometheus-service-broker writes JSON files to an S3 bucket which detail the target to monitor, target labels to use for the target, and the application guid which is used by the instrumentation libraries to protect the /metrics endpoint on the app using basic auth.
 - A cron job running on each Prometheus instance syncs these files to the config directory so that Prometheus can pick up the changes.
 
 ### AWS Nginx configuration
@@ -126,10 +126,10 @@ Nginx is set up in front of Prometheus and acts as an ingress/egress request pro
 #### paas-proxy:
 A forward proxy is used for the traffic from Prometheus to PaaS for two purposes.
 
-- **Custom header insertion**:
+- Custom header insertion:
 custom headers [X-CF-APP-INSTANCE](https://docs.cloudfoundry.org/concepts/http-routing.html#app-instance-routing), which is a CloudFoundry-specific header which requests a specific instance ID to scrape, is inserted to requests from Prometheus to PaaS so that Prometheus can get metrics from each instance of an app - [EC2 Nginx config](https://github.com/alphagov/prometheus-aws-configuration-beta/blob/master/terraform/modules/prom-ec2/prometheus/cloud.conf#L66).
 
-- **Bearer token**:
+- Bearer token:
 Set to be CloudFoundry app guid, bearer token is used to authorise the connection to the /metrics endpoint for metrics exporters running on PaaS - [EC2 Nginx config](https://github.com/alphagov/prometheus-aws-configuration-beta/blob/master/terraform/modules/prom-ec2/prometheus/cloud.conf#L67).
 
 #### auth-proxy
@@ -137,10 +137,10 @@ Basic auth is used to protect inbound access to Prometheus [EC2 Nginx config] (h
 
 
 ### AWS session manager
-We use AWS session manager for accessing AWS node instances via the [systems manager console](https://eu-west-1.console.aws.amazon.com/systems-manager/home?region=eu-west-1#) (login to aws first) or CLI. We do this instead of sshing into the node and do not need a bastion host in our architecture.
+We use AWS session manager for accessing AWS node instances using the [systems manager console](https://eu-west-1.console.aws.amazon.com/systems-manager/home?region=eu-west-1#) (login to aws first) or CLI. We do this instead of sshing into the node and do not need a bastion host in our architecture.
 
 ### IP safelist for PaaS routes
-PaaS tenants can optionally deploy an [IP safelist service](https://docs.cloud.service.gov.uk/deploying_services/route_services/) on PaaS, which is based on [PaaS route service](https://docs.cloud.service.gov.uk/deploying_services/route_services/#route-services) that provides a full proxy for application routes for applications on PaaS, e.g. [prometheus-metric-exporter](https://github.com/alphagov/paas-prometheus-exporter) that are bound to it. PaaS tenants can use the route service to provide an IP restriction layer before web requests hit the applications running on PaaS.
+PaaS tenants can optionally deploy an [IP safelist service](https://docs.cloud.service.gov.uk/deploying_services/route_services/) on PaaS, which is based on [PaaS route service](https://docs.cloud.service.gov.uk/deploying_services/route_services/#route-services) that provides a full proxy for application routes for applications on PaaS, for example [prometheus-metric-exporter](https://github.com/alphagov/paas-prometheus-exporter) that are bound to it. PaaS tenants can use the route service to provide an IP restriction layer before web requests hit the applications running on PaaS.
 
 ### Logging, monitoring and alerting
 The following apps and SaaS are used for monitoring, logging and alerting for the prometheus-for-PaaS.
@@ -297,8 +297,8 @@ When triaging an issue you should take some time to ask the following questions:
 - is someone else already looking at the issue
   - slack the `#re-autom8` channel, ask the team and look at existing Trello cards.
 - what impact is it having on tenants:
-  - High - does it affect their services, i.e. cause problems with deployments, affects performance of their apps.
-  - Mid - does it impact their metrics collection, i.e. see unexpected gaps in metrics, or odd values, loss of historical metrics.
+  - High - does it affect their services, such as causing problems with deployments or affecting performance of their apps.
+  - Mid - does it impact their metrics collection, such as seeing unexpected gaps in metrics, odd values, or loss of historical metrics.
   - Low - is it causing problems in viewing metrics on Grafana, but metrics are still being collected and stored.
 - how long will the issue take to resolve
   - get estimate from the person who is working on resolving the issue.
@@ -353,7 +353,7 @@ We still need to define and implement SLIs for all of our most important user ev
 
 Alert delivery is one of the main things our users rely on. The purpose of this alert is to provide confidence that an alert that fires in Prometheus will be sent from Alertmanager by using a dead mans switch.
 
-This alert is configured to always be firing (so will appear red in Prometheus and as alerting in Alertmanager). The alerts are sent to Cronitor our external monitoring service. If Cronitor has not received an alert from our Alertmanagers for 10 minutes then an alert is raised via Pagerduty.
+This alert is configured to always be firing (so will appear red in Prometheus and as alerting in Alertmanager). The alerts are sent to Cronitor our external monitoring service. If Cronitor has not received an alert from our Alertmanagers for 10 minutes then an alert is raised using Pagerduty.
 
 The Pagerduty alert title will include: RE Observe Heartbeat Production
 
@@ -386,7 +386,7 @@ The current number of Alertmanagers running in production has gone below two.
 
 <%= partial 'documentation/prometheus-for-gds-paas/support_blurb.md.erb' %>
 
-Prometheus has no targets via file service discovery for the GOV.UK PaaS.
+Prometheus has no targets using file service discovery for the GOV.UK PaaS.
 
 It is possible that this is represents a problem with the service broker's
 operation that generates the targets for prometheus to scrape, or it may be
@@ -491,10 +491,10 @@ This alert is used as a catch all to identify failing targets that may have no r
 
 You should identify who is responsible for the target and check their alerting rules to see if they would have been notified of this. If they would not have received an alert because they do not have one set up then you should contact them.
 
-If the target is a leftover test app deployed by ourselves then check with the team but we may delete the application if no longer needed or unbind the service from the app, either [manually](https://cli.cloudfoundry.org/en-US/cf/unbind-service.html) or by removing the service from the application manifest.
+If the target is a leftover test app deployed by ourselves then check with the team but we may delete the application if no longer needed or unbind the service from the app, either by [manually running `cf unbind-service`](https://cli.cloudfoundry.org/en-US/cf/unbind-service.html) or by removing the service from the application manifest.
 
 We have also seen a potential bug with our PaaS service discovery leaving targets for
-blue-green deployed apps even after the old (also known as venerable) application has been deleted. If this is the case we should try and identify what caused it. If we can't figure out why, manually delete the file from the [govukobserve-targets-production bucket](https://s3.console.aws.amazon.com/s3/object/govukobserve-targets-production).
+blue-green deployed apps even after the old (also known as venerable) application has been deleted. If this is the case we should try and identify what caused it. If we cannot figure out why, manually delete the file from the [govukobserve-targets-production bucket](https://s3.console.aws.amazon.com/s3/object/govukobserve-targets-production).
 
 #### Links
 
@@ -524,7 +524,7 @@ gds aws re-prom-prod -- aws s3 sync --delete . s3://govukobserve-london-targets-
 
 <%= partial 'documentation/prometheus-for-gds-paas/support_blurb.md.erb' %>
 
-The Grafana endpoint hasn't been successfully scraped for over 5 minutes. This may be caused by:
+The Grafana endpoint has not been successfully scraped for over 5 minutes. This may be caused by:
 
 1. A deploy is taking longer than expected.
 2. An issue with the PaaS.
@@ -553,7 +553,7 @@ If the issues are not affecting services  (Users are able to continue to use the
 
 ### There is a problem with one of the Prometheus tenants
 
-Put a message in slack: `#re-prometheus-support` and speak to someone in the [team](https://docs.google.com/document/d/1WLKqmpSHUbOVygkdJkewM1bj7lOK0MC-r8sBpTIHBzs/edit) who is responsible for the service which has a problem.
+Put a message in slack: `#re-prometheus-support` and speak to someone in the team who is responsible for the service which has a problem.
 
 
 ### Adding and editing Grafana permissions
@@ -590,7 +590,7 @@ a datasource our users dashboards will start breaking as they will still using t
 
 8. Repeat step 6 for production.
 
-9. Let users know via the #re-prometheus-support Slack channel that they may need to refresh any Grafana dashboards they
+9. Let users know using the #re-prometheus-support Slack channel that they may need to refresh any Grafana dashboards they
 have open to use the new basic auth credentials.
 
 
@@ -598,18 +598,18 @@ have open to use the new basic auth credentials.
 
 The major development milestones are summarized as follow:
 
-####Year/Quarter: 2018/Q1
+### Year/Quarter: 2018/Q1
 
-Alpha [Previous docs](https://github.com/alphagov/monitoring-doc/tree/master/diagrams)
+[Alpha architecture diagrams](https://github.com/alphagov/monitoring-doc/tree/master/diagrams)
 
 - Self hosted and configured a prometheus instance on AWS EC2
 - Deployed nginx auth-proxy and paas-proxy on the same EC2 machines
 - Developed exporters to expose apps and service metrics to be scraped by prometheus
 - Developed PaaS service-broker for the exporters for PaaS tenants to export their metrics to Prometheus
 
-####Year/Quarter: 2018/Q2-3
+### Year/Quarter: 2018/Q2-3
 
-Beta [Previous docs](https://docs.google.com/document/d/1FFT6lqOknXNYfGYptTJ8E-8LPdroN7jvTQACSjjBUtU/edit#heading=h.iznzu7xflj1)
+[Beta architecture diagrams](https://docs.google.com/document/d/1FFT6lqOknXNYfGYptTJ8E-8LPdroN7jvTQACSjjBUtU/edit#heading=h.iznzu7xflj1)
 
 - Deploy 3 instances of Prometheus on AWS ECS
 - Deployed 3 instances of Alertmanager on AWS ECS
@@ -619,11 +619,11 @@ Beta [Previous docs](https://docs.google.com/document/d/1FFT6lqOknXNYfGYptTJ8E-8
 - Successfully tested 2 instances of Alertmanager running on the new Kubernetes platform
 - Started migration of Nginx auth-proxy and paas-proxy back from ECS to EC2
 
-#### Year/Quarter: 2019/Q4
+### Year/Quarter: 2019/Q4
 
 - Fixed meshing across the Alertmanagers
 - Migrated Alertmanagers to Fargate
-- Made Alertmanagers continously deployed via Concourse
+- Made Alertmanagers continously deployed through Concourse
 
 
 


### PR DESCRIPTION
The deadline for publishing an accessibility statement for public sector websites is 23 September 2020. As part of this project, the tech writing team is:

- reviewing all tech content that is public and uses the tech doc template
- pushing fixes where possible to increase accessibility of the content
- publishing an accessibility statement for that content

Due to compressed timescales, for some tech content, the tech writing team is doing a lightweight audit on a selection or specific page of that content. We've done a lightweight audit for the RE team manual. of [this page](https://re-team-manual.cloudapps.digital/prometheus-for-gds-paas-users.html#prometheus-for-gds-paas-service). 

This PR contains the accessibility fixes identified during the lightweight audit of this content. This includes:

- making sure there are no skipped heading levels
- changing links to be descriptive
- ensuring that the content itself always uses sentence case, and does not use bold, italics or underlined text unnecessarily
- removes inaccessible language like e.g., i.e., ad hoc, and via

The content of the RE team manual needs an accessibility statement as well. This will be handled in a separate PR. 