### PR TITLE
Add accessibility statement

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -15,6 +15,9 @@ header_links:
   Documentation: /
   GitHub: https://github.com/alphagov/re-team-manual
 
+footer_links:
+  Accessibility: /accessibility.html
+
 enable_search: true
 
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -1,0 +1,75 @@
+---
+title: Accessibility statement for Reliability Engineering Team Manual
+last_reviewed_on: 2020-09-07
+review_in: 6 months
+hide_in_navigation: true
+---
+
+# Accessibility statement for Reliability Engineering Team Manual
+
+This accessibility statement applies to the Reliability Engineering Team Manual at [https://re-team-manual.cloudapps.digital/](https://re-team-manual.cloudapps.digital/).
+
+This website is run by the Reliability Engineering team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
++ change colours, contrast levels and fonts
++ zoom in up to 300% without the text spilling off the screen
++ navigate most of the website using just a keyboard
++ navigate most of the website using speech recognition software
++ listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+We’ve also made the website text as simple as possible to understand.
+
+[AbilityNet](https://mcmw.abilitynet.org.uk/) has advice on making your device easier to use if you have a disability.
+
+## How accessible this website is
+
+We know some parts of this website are not fully accessible:
+
+- multiple pages have redundant links
+- multiple headings are empty links with no text in their anchor elements
+- there are issues caused by our Technical Documentation Template
+
+## Feedback and contact information
+
+If you need any part of this service in a different format like large print, audio recording or braille, email [reliability-engineering@digital.cabinet-office.gov.uk](reliability-engineering@digital.cabinet-office.gov.uk).
+
+We’ll consider your request and get back to you within 3 working days.
+
+## Reporting accessibility problems with this website
+
+We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email [reliability-engineering@digital.cabinet-office.gov.uk](reliability-engineering@digital.cabinet-office.gov.uk).
+
+### Enforcement procedure
+
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
+(the ‘accessibility regulations’). If you’re not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com/).
+
+## Technical information about this website’s accessibility
+
+GDS is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+### Compliance status
+
+This website is partially compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard, due to the non-compliances listed below.
+
+### Non-accessible content
+
+The content listed below is non-accessible for the following reasons.
+
+#### Non-compliance with the accessibility regulations
+
+Multiple pages have redundant links. This is not a fail, but should be looked at under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
+
+Multiple headings are empty links with no text in the anchor elements. This is a fail under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
+
+Some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
+
+## What we’re doing to improve accessibility
+
+We plan to look at fixing the identified content issues and the issues with the Technical Documentation Template by the end of 2020.
+
+## Preparation of this accessibility statement
+
+This statement was prepared on 7 September 2020. It was last reviewed on 7 September 2020.
+
+This website was last tested in September 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a selection of the website's pages.

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -5,14 +5,14 @@ review_in: 6 months
 hide_in_navigation: true
 ---
 
-# Accessibility statement for Reliability Engineering Team Manual
+# Accessibility statement for Reliability Engineering team manual
 
 This accessibility statement applies to the Reliability Engineering Team Manual at [https://re-team-manual.cloudapps.digital/](https://re-team-manual.cloudapps.digital/).
 
 This website is run by the Reliability Engineering team at the Government Digital Service (GDS). We want as many people as possible to be able to use this website. For example, that means you should be able to:
 
 + change colours, contrast levels and fonts
-+ zoom in up to 300% without the text spilling off the screen
++ zoom in up to 300% without problems
 + navigate most of the website using just a keyboard
 + navigate most of the website using speech recognition software
 + listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
@@ -23,17 +23,16 @@ We’ve also made the website text as simple as possible to understand.
 
 ## How accessible this website is
 
-We know some parts of this website are not fully accessible:
+We know some parts of this website are not fully accessible for the following reasons:
 
-- multiple pages have redundant links
-- multiple headings are empty links with no text in their anchor elements
+- some pages have redundant links
 - there are issues caused by our Technical Documentation Template
 
 ## Feedback and contact information
 
 If you need any part of this service in a different format like large print, audio recording or braille, email [reliability-engineering@digital.cabinet-office.gov.uk](reliability-engineering@digital.cabinet-office.gov.uk).
 
-We’ll consider your request and get back to you within 3 working days.
+We’ll aim to get back to you within 3 working days.
 
 ## Reporting accessibility problems with this website
 
@@ -58,15 +57,13 @@ The content listed below is non-accessible for the following reasons.
 
 #### Non-compliance with the accessibility regulations
 
-Multiple pages have redundant links. This is not a fail, but should be looked at under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
+Some pages have redundant links. This is not a fail, but should be looked at under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
 
-Multiple headings are empty links with no text in the anchor elements. This is a fail under [WCAG 2.1 success criterion 2.4.4 Link Purpose (In Context)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html).
-
-Some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
+Some parts of this website are not fully accessible because of [issues caused by our Technical Documentation Template](https://tdt-documentation.london.cloudapps.digital/accessibility/#using-the-technical-documentation-template-for-your-own-documentation).
 
 ## What we’re doing to improve accessibility
 
-We plan to look at fixing the identified content issues and the issues with the Technical Documentation Template by the end of 2020.
+We plan to fix the content issues and the issues with the Technical Documentation Template by the end of 2020.
 
 ## Preparation of this accessibility statement
 


### PR DESCRIPTION
The deadline for publishing an accessibility statement for public sector websites is 23 September 2020. As part of this project, the tech writing team is:

- reviewing all tech content that is public and uses the tech doc template
- pushing fixes where possible to increase accessibility of the content
- publishing an accessibility statement for that content

Due to compressed timescales, for some tech content, the tech writing team is doing a lightweight audit on a selection or specific page of that content. We've done a lightweight audit for the RE team manual.

This PR contains the accessibility statement. The accessibility fixes identified in the audit are part of this PR: https://github.com/alphagov/re-team-manual/pull/161

