### PR TITLE
Update tech docs template date to March 2021

### DIFF
--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -63,7 +63,7 @@ Some parts of this website are not fully accessible because of [issues caused by
 
 ## What we’re doing to improve accessibility
 
-We plan to fix the content issues and the issues with the Technical Documentation Template by the end of 2020.
+We plan to fix the content issues and the issues with the Technical Documentation Template by the end of March 2021.
 
 ## Preparation of this accessibility statement
 


### PR DESCRIPTION
We will not be able to fix the accessibility related issues for the tech docs template by the end of 2020.

We are extending the date to end of March 2021. Hopefully by that point we will have some developer resource to look at these issues.