### PR TITLE
Change target dates for accessibility fixes

### DIFF
--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -63,10 +63,10 @@ Some parts of this website are not fully accessible because of [issues caused by
 
 ## What we’re doing to improve accessibility
 
-We plan to fix the content issues and the issues with the Technical Documentation Template by the end of 2020.
+We plan to fix the content issues and the issues with the Technical Documentation Template by the end of March 2021.
 
 ## Preparation of this accessibility statement
 
-This statement was prepared on 7 September 2020. It was last reviewed on 7 September 2020.
+This statement was prepared on 7 September 2020. It was last reviewed on 21 December 2020.
 
 This website was last tested in September 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a selection of the website's pages.


### PR DESCRIPTION
Updated the date for fixing the Tech Docs Template accessibility issues from “end of December 2020” to “end of March 2021”. As a result of resourcing pressures and re-prioritisation this year, it’s taking longer than we hoped to arrange developer and designer resources to fix the accessibility issues.