### PR TITLE
autom8 on-call/interruptible: add section on secrets over-requesting

### DIFF
--- a/source/documentation/automate-on-call-interruptible.md
+++ b/source/documentation/automate-on-call-interruptible.md
@@ -274,7 +274,7 @@ The recommended way of accessing this database is through connecting to one of t
 
 Certain people are authorised to, when necessary, assume `owner` level permissions in all teams. To trigger this:
 * Browse to https://cd.gds-reliability.engineering/teams/main/pipelines/temporary-owners-promoter
-* Select `promote-<username>` (if there is not one for your username, you are not authorised to do this).
+* Select `promote-<username>` (if there is not one for your username, you are not authorised to do this, or the `update-pipeline` job hasn't run since you were given that permission).
 * Trigger Build using the usual plus button in the top right.
 * You may now need to log out of Concourse and log back in. You may need to repeat this process with fly.
 * When you are done, either trigger a build of `demote-<username>`, or `demote-all-owners`. If you forget, `demote-all-owners` runs daily anyway.

--- a/source/documentation/automate-on-call-interruptible.md
+++ b/source/documentation/automate-on-call-interruptible.md
@@ -216,6 +216,8 @@ repository.
 Useful links:
 
 * [Multi-tenant concourse](https://cd.gds-reliability.engineering/)
+* [Concourse grafana](https://grafana.monitoring.cd.gds-reliability.engineering/)
+* [Concourse prometheus](https://prom-1.monitoring.cd.gds-reliability.engineering/)
 * [tech-ops repository](https://github.com/alphagov/tech-ops)
 * [tech-ops-private repository](https://github.com/alphagov/tech-ops-private)
 


### PR DESCRIPTION
https://trello.com/c/2yqqA8Lb

Needed at least an excuse to be able to link to the secrets dashboard from
somewhere "official". Explained the situation hopefully omitting overly specific detail that may go out of date easily.

Also took the chance to add a couple other clarifications.